### PR TITLE
🔀 ::(#5) - Enable local.properties in the network module

### DIFF
--- a/core/network/build.gradle.kts
+++ b/core/network/build.gradle.kts
@@ -1,3 +1,6 @@
+import java.io.FileInputStream
+import java.util.Properties
+
 @Suppress("DSL_SCOPE_VIOLATION")
 plugins {
     id("bitgoeul.android.core")
@@ -8,6 +11,11 @@ android {
     buildFeatures {
         buildConfig = true
     }
+
+    defaultConfig {
+        buildConfigField("String", "BASE_URL",  getApiKey("BASE_URL"))
+    }
+
     namespace = "com.msg.network"
 }
 
@@ -21,4 +29,10 @@ dependencies {
     implementation(libs.okhttp.logging)
     implementation(libs.retrofit.core)
     implementation(libs.retrofit.kotlin.serialization)
+}
+fun getApiKey(propertyKey: String): String {
+    val propFile = rootProject.file("./local.properties")
+    val properties = Properties()
+    properties.load(FileInputStream(propFile))
+    return properties.getProperty(propertyKey)
 }


### PR DESCRIPTION
## 💡 개요
local.properties를 network module에서 사용할 수 있도록 설정
## 📃 작업내용
- add getApi function in build.gradle(:core:network)
- add buildConfig in build.gradle(:core:network)
## 🔀 변경사항

## 🙋‍♂️ 질문사항

## 🍴 사용방법

## 🎸 기타
