### PR TITLE
🔀 :: (#41) - Set up network on Logout part

### DIFF
--- a/core/data/src/main/java/com/msg/data/repository/AuthRepository.kt
+++ b/core/data/src/main/java/com/msg/data/repository/AuthRepository.kt
@@ -17,4 +17,5 @@ interface AuthRepository {
     suspend fun signUpProfessor(body: SignUpProfessorRequest): Flow<Unit>
     suspend fun signUpGovernment(body: SignUpGovernmentRequest): Flow<Unit>
     suspend fun signUpCompanyInstructor(body: SignUpCompanyInstructorRequest): Flow<Unit>
+    suspend fun logout(): Flow<Unit>
 }

--- a/core/data/src/main/java/com/msg/data/repository/AuthRepositoryImpl.kt
+++ b/core/data/src/main/java/com/msg/data/repository/AuthRepositoryImpl.kt
@@ -60,4 +60,8 @@ class AuthRepositoryImpl @Inject constructor(
             body = body
         )
     }
+
+    override suspend fun logout(): Flow<Unit> {
+        return authDataSource.logout()
+    }
 }

--- a/core/domain/src/main/java/com/msg/domain/auth/LogoutUseCase.kt
+++ b/core/domain/src/main/java/com/msg/domain/auth/LogoutUseCase.kt
@@ -1,0 +1,12 @@
+package com.msg.domain.auth
+
+import com.msg.data.repository.AuthRepository
+import javax.inject.Inject
+
+class LogoutUseCase @Inject constructor(
+    private val authRepository: AuthRepository
+) {
+    suspend operator fun invoke() = runCatching {
+        authRepository.logout()
+    }
+}

--- a/core/network/src/main/java/com/msg/network/api/AuthAPI.kt
+++ b/core/network/src/main/java/com/msg/network/api/AuthAPI.kt
@@ -8,6 +8,7 @@ import com.msg.model.remote.request.SignUpJobClubTeacherRequest
 import com.msg.model.remote.request.SignUpProfessorRequest
 import com.msg.model.remote.request.SignUpStudentRequest
 import retrofit2.http.Body
+import retrofit2.http.DELETE
 import retrofit2.http.POST
 
 interface AuthAPI {
@@ -40,4 +41,7 @@ interface AuthAPI {
     suspend fun signUpCompanyInstructor(
         @Body body: SignUpCompanyInstructorRequest
     )
+
+    @DELETE("auth")
+    suspend fun logout()
 }

--- a/core/network/src/main/java/com/msg/network/datasource/auth/AuthDataSource.kt
+++ b/core/network/src/main/java/com/msg/network/datasource/auth/AuthDataSource.kt
@@ -16,4 +16,5 @@ interface AuthDataSource {
     suspend fun signUpProfessor(body: SignUpProfessorRequest): Flow<Unit>
     suspend fun signUpGovernment(body: SignUpGovernmentRequest): Flow<Unit>
     suspend fun signUpCompanyInstructor(body: SignUpCompanyInstructorRequest): Flow<Unit>
+    suspend fun logout(): Flow<Unit>
 }

--- a/core/network/src/main/java/com/msg/network/datasource/auth/AuthDataSourceImpl.kt
+++ b/core/network/src/main/java/com/msg/network/datasource/auth/AuthDataSourceImpl.kt
@@ -66,4 +66,12 @@ class AuthDataSourceImpl @Inject constructor(
                 .sendRequest()
         )
     }.flowOn(Dispatchers.IO)
+
+    override suspend fun logout(): Flow<Unit> = flow {
+        emit(
+            BitgoeulApiHandler<Unit>()
+                .httpRequest { authAPI.logout() }
+                .sendRequest()
+        )
+    }
 }


### PR DESCRIPTION
## 💡 개요
로그아웃 파트 통신 세팅을 합니다.
## 📃 작업내용
- add logout fun in AuthAPI
- add logout fun in AuthDataSource
- add logout fun in AuthRepository
- add LogoutUseCase