### PR TITLE
🔀 :: (#64) - Set up network on add student activity info

### DIFF
--- a/core/data/src/main/java/com/msg/data/di/RepositoryModule.kt
+++ b/core/data/src/main/java/com/msg/data/di/RepositoryModule.kt
@@ -1,5 +1,7 @@
 package com.msg.data.di
 
+import com.msg.data.repository.activity.ActivityRepository
+import com.msg.data.repository.activity.ActivityRepositoryImpl
 import com.msg.data.repository.auth.AuthRepository
 import com.msg.data.repository.auth.AuthRepositoryImpl
 import com.msg.data.repository.lecture.LectureRepository
@@ -21,4 +23,9 @@ abstract class RepositoryModule {
     abstract fun bindLectureRepository(
         lectureRepositoryImpl: LectureRepositoryImpl
     ): LectureRepository
+
+    @Binds
+    abstract fun bindActivityRepository(
+        activityRepositoryImpl: ActivityRepositoryImpl
+    ): ActivityRepository
 }

--- a/core/data/src/main/java/com/msg/data/repository/activity/ActivityRepository.kt
+++ b/core/data/src/main/java/com/msg/data/repository/activity/ActivityRepository.kt
@@ -1,0 +1,4 @@
+package com.msg.data.repository.activity
+
+interface ActivityRepository {
+}

--- a/core/data/src/main/java/com/msg/data/repository/activity/ActivityRepository.kt
+++ b/core/data/src/main/java/com/msg/data/repository/activity/ActivityRepository.kt
@@ -1,4 +1,9 @@
 package com.msg.data.repository.activity
 
+import com.msg.model.remote.model.activity.StudentActivityModel
+import kotlinx.coroutines.flow.Flow
+
+
 interface ActivityRepository {
+    suspend fun addStudentActivityInfo(body: StudentActivityModel): Flow<Unit>
 }

--- a/core/data/src/main/java/com/msg/data/repository/activity/ActivityRepositoryImpl.kt
+++ b/core/data/src/main/java/com/msg/data/repository/activity/ActivityRepositoryImpl.kt
@@ -1,9 +1,17 @@
 package com.msg.data.repository.activity
 
+import com.msg.model.remote.model.activity.StudentActivityModel
 import com.msg.network.datasource.activity.ActivityDataSource
+import kotlinx.coroutines.flow.Flow
 import javax.inject.Inject
 
 class ActivityRepositoryImpl @Inject constructor(
-    activityDataSource: ActivityDataSource
+    private val activityDataSource: ActivityDataSource
 ) : ActivityRepository {
+    override suspend fun addStudentActivityInfo(body: StudentActivityModel): Flow<Unit> {
+        return activityDataSource.addStudentActivityInfo(
+            body = body
+        )
+    }
+
 }

--- a/core/data/src/main/java/com/msg/data/repository/activity/ActivityRepositoryImpl.kt
+++ b/core/data/src/main/java/com/msg/data/repository/activity/ActivityRepositoryImpl.kt
@@ -1,0 +1,9 @@
+package com.msg.data.repository.activity
+
+import com.msg.network.datasource.activity.ActivityDataSource
+import javax.inject.Inject
+
+class ActivityRepositoryImpl @Inject constructor(
+    activityDataSource: ActivityDataSource
+) : ActivityRepository {
+}

--- a/core/domain/src/main/java/com/msg/domain/activity/AddStudentActivityInfoUseCase.kt
+++ b/core/domain/src/main/java/com/msg/domain/activity/AddStudentActivityInfoUseCase.kt
@@ -1,0 +1,13 @@
+package com.msg.domain.activity
+
+import com.msg.data.repository.activity.ActivityRepository
+import com.msg.model.remote.model.activity.StudentActivityModel
+import javax.inject.Inject
+
+class AddStudentActivityInfoUseCase @Inject constructor(
+    private val activityRepository: ActivityRepository
+) {
+    suspend operator fun invoke(body: StudentActivityModel) = runCatching {
+        activityRepository.addStudentActivityInfo(body = body)
+    }
+}

--- a/core/model/src/main/java/com/msg/model/remote/model/activity/StudentActivityModel.kt
+++ b/core/model/src/main/java/com/msg/model/remote/model/activity/StudentActivityModel.kt
@@ -1,0 +1,10 @@
+package com.msg.model.remote.model.activity
+
+import java.time.LocalDateTime
+
+data class StudentActivityModel(
+    val title: String,
+    val content: String,
+    val credit: Int,
+    val activityDate: LocalDateTime
+)

--- a/core/network/src/main/java/com/msg/network/api/ActivityAPI.kt
+++ b/core/network/src/main/java/com/msg/network/api/ActivityAPI.kt
@@ -5,4 +5,8 @@ import retrofit2.http.Body
 import retrofit2.http.POST
 
 interface ActivityAPI {
+    @POST("activity")
+    suspend fun addStudentActivityInfo(
+        @Body body: StudentActivityModel
+    )
 }

--- a/core/network/src/main/java/com/msg/network/api/ActivityAPI.kt
+++ b/core/network/src/main/java/com/msg/network/api/ActivityAPI.kt
@@ -1,0 +1,8 @@
+package com.msg.network.api
+
+import com.msg.model.remote.model.activity.StudentActivityModel
+import retrofit2.http.Body
+import retrofit2.http.POST
+
+interface ActivityAPI {
+}

--- a/core/network/src/main/java/com/msg/network/datasource/activity/ActivityDataSource.kt
+++ b/core/network/src/main/java/com/msg/network/datasource/activity/ActivityDataSource.kt
@@ -1,4 +1,8 @@
 package com.msg.network.datasource.activity
 
+import com.msg.model.remote.model.activity.StudentActivityModel
+import kotlinx.coroutines.flow.Flow
+
 interface ActivityDataSource {
+    suspend fun addStudentActivityInfo(body: StudentActivityModel): Flow<Unit>
 }

--- a/core/network/src/main/java/com/msg/network/datasource/activity/ActivityDataSource.kt
+++ b/core/network/src/main/java/com/msg/network/datasource/activity/ActivityDataSource.kt
@@ -1,0 +1,4 @@
+package com.msg.network.datasource.activity
+
+interface ActivityDataSource {
+}

--- a/core/network/src/main/java/com/msg/network/datasource/activity/ActivityDataSourceImpl.kt
+++ b/core/network/src/main/java/com/msg/network/datasource/activity/ActivityDataSourceImpl.kt
@@ -1,9 +1,22 @@
 package com.msg.network.datasource.activity
 
+import com.msg.model.remote.model.activity.StudentActivityModel
 import com.msg.network.api.ActivityAPI
+import com.msg.network.util.BitgoeulApiHandler
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.flow
+import kotlinx.coroutines.flow.flowOn
 import javax.inject.Inject
 
 class ActivityDataSourceImpl @Inject constructor(
     private val activityAPI: ActivityAPI
 ) : ActivityDataSource {
+    override suspend fun addStudentActivityInfo(body: StudentActivityModel): Flow<Unit> = flow {
+        emit(
+            BitgoeulApiHandler<Unit>()
+                .httpRequest { activityAPI.addStudentActivityInfo(body = body) }
+                .sendRequest()
+        )
+    }.flowOn(Dispatchers.IO)
 }

--- a/core/network/src/main/java/com/msg/network/datasource/activity/ActivityDataSourceImpl.kt
+++ b/core/network/src/main/java/com/msg/network/datasource/activity/ActivityDataSourceImpl.kt
@@ -1,0 +1,9 @@
+package com.msg.network.datasource.activity
+
+import com.msg.network.api.ActivityAPI
+import javax.inject.Inject
+
+class ActivityDataSourceImpl @Inject constructor(
+    private val activityAPI: ActivityAPI
+) : ActivityDataSource {
+}

--- a/core/network/src/main/java/com/msg/network/di/DataSourceModule.kt
+++ b/core/network/src/main/java/com/msg/network/di/DataSourceModule.kt
@@ -1,5 +1,7 @@
 package com.msg.network.di
 
+import com.msg.network.datasource.activity.ActivityDataSource
+import com.msg.network.datasource.activity.ActivityDataSourceImpl
 import com.msg.network.datasource.auth.AuthDataSource
 import com.msg.network.datasource.auth.AuthDataSourceImpl
 import com.msg.network.datasource.lecture.LectureDataSource
@@ -21,4 +23,9 @@ abstract class DataSourceModule {
     abstract fun bindLectureDataSource(
         lectureDataSourceImpl: LectureDataSourceImpl
     ): LectureDataSource
+
+    @Binds
+    abstract fun bindActivityDataSource(
+        activityDataSourceImpl: ActivityDataSourceImpl
+    ): ActivityDataSource
 }

--- a/core/network/src/main/java/com/msg/network/di/NetworkModule.kt
+++ b/core/network/src/main/java/com/msg/network/di/NetworkModule.kt
@@ -2,6 +2,7 @@ package com.msg.network.di
 
 import android.util.Log
 import com.msg.network.BuildConfig
+import com.msg.network.api.ActivityAPI
 import com.msg.network.api.AuthAPI
 import com.msg.network.api.LectureAPI
 import com.msg.network.util.AuthInterceptor
@@ -63,4 +64,8 @@ object NetworkModule {
     @Provides
     fun provideLectureAPI(retrofit: Retrofit): LectureAPI =
         retrofit.create(LectureAPI::class.java)
+
+    @Provides
+    fun provideActivityAPI(retrofit: Retrofit): ActivityAPI =
+        retrofit.create(ActivityAPI::class.java)
 }


### PR DESCRIPTION
## 💡 개요
학생활동정보추가 네트워크 파트 세팅
## 📃 작업내용
- add StudentActivityModel
- add ActivityAPI
- provide ActivityAPI
- add addStudentActivityInfo fun in ActivityAPI
- add ActivityDataSource and ActivityDataSourceImpl
- bind ActivityDataSource
- add addStudentActivityInfo fun in ActivityDataSource
- add ActivityRepository and ActivityRepositoryImpl
- bind ActivityRepository
- add addStudentActivityInfo fun in ActivityRepository
- add AddStudentActivityInfoUseCase