### PR TITLE
🔀 :: (#67) - Set up network on edit student activity info

### DIFF
--- a/core/data/src/main/java/com/msg/data/repository/activity/ActivityRepository.kt
+++ b/core/data/src/main/java/com/msg/data/repository/activity/ActivityRepository.kt
@@ -2,8 +2,10 @@ package com.msg.data.repository.activity
 
 import com.msg.model.remote.model.activity.StudentActivityModel
 import kotlinx.coroutines.flow.Flow
+import java.util.UUID
 
 
 interface ActivityRepository {
     suspend fun addStudentActivityInfo(body: StudentActivityModel): Flow<Unit>
+    suspend fun editStudentActivityInfo(id: UUID, body: StudentActivityModel): Flow<Unit>
 }

--- a/core/data/src/main/java/com/msg/data/repository/activity/ActivityRepositoryImpl.kt
+++ b/core/data/src/main/java/com/msg/data/repository/activity/ActivityRepositoryImpl.kt
@@ -3,6 +3,7 @@ package com.msg.data.repository.activity
 import com.msg.model.remote.model.activity.StudentActivityModel
 import com.msg.network.datasource.activity.ActivityDataSource
 import kotlinx.coroutines.flow.Flow
+import java.util.UUID
 import javax.inject.Inject
 
 class ActivityRepositoryImpl @Inject constructor(
@@ -14,4 +15,10 @@ class ActivityRepositoryImpl @Inject constructor(
         )
     }
 
+    override suspend fun editStudentActivityInfo(id: UUID, body: StudentActivityModel): Flow<Unit> {
+        return activityDataSource.editStudentActivityInfo(
+            id = id,
+            body = body
+        )
+    }
 }

--- a/core/domain/src/main/java/com/msg/domain/activity/EditStudentActivityInfoUseCase.kt
+++ b/core/domain/src/main/java/com/msg/domain/activity/EditStudentActivityInfoUseCase.kt
@@ -1,0 +1,14 @@
+package com.msg.domain.activity
+
+import com.msg.data.repository.activity.ActivityRepository
+import com.msg.model.remote.model.activity.StudentActivityModel
+import java.util.UUID
+import javax.inject.Inject
+
+class EditStudentActivityInfoUseCase  @Inject constructor(
+    private val activityRepository: ActivityRepository
+) {
+    suspend operator fun invoke(id: UUID,body: StudentActivityModel) = runCatching {
+        activityRepository.editStudentActivityInfo(id = id, body = body)
+    }
+}

--- a/core/network/src/main/java/com/msg/network/api/ActivityAPI.kt
+++ b/core/network/src/main/java/com/msg/network/api/ActivityAPI.kt
@@ -2,11 +2,20 @@ package com.msg.network.api
 
 import com.msg.model.remote.model.activity.StudentActivityModel
 import retrofit2.http.Body
+import retrofit2.http.PATCH
 import retrofit2.http.POST
+import retrofit2.http.Path
+import java.util.UUID
 
 interface ActivityAPI {
     @POST("activity")
     suspend fun addStudentActivityInfo(
+        @Body body: StudentActivityModel
+    )
+
+    @PATCH("patch/{id}")
+    suspend fun editStudentActivityInfo(
+        @Path("id") id: UUID,
         @Body body: StudentActivityModel
     )
 }

--- a/core/network/src/main/java/com/msg/network/datasource/activity/ActivityDataSource.kt
+++ b/core/network/src/main/java/com/msg/network/datasource/activity/ActivityDataSource.kt
@@ -2,7 +2,9 @@ package com.msg.network.datasource.activity
 
 import com.msg.model.remote.model.activity.StudentActivityModel
 import kotlinx.coroutines.flow.Flow
+import java.util.UUID
 
 interface ActivityDataSource {
     suspend fun addStudentActivityInfo(body: StudentActivityModel): Flow<Unit>
+    suspend fun editStudentActivityInfo(id: UUID, body: StudentActivityModel): Flow<Unit>
 }

--- a/core/network/src/main/java/com/msg/network/datasource/activity/ActivityDataSourceImpl.kt
+++ b/core/network/src/main/java/com/msg/network/datasource/activity/ActivityDataSourceImpl.kt
@@ -7,6 +7,7 @@ import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.flow
 import kotlinx.coroutines.flow.flowOn
+import java.util.UUID
 import javax.inject.Inject
 
 class ActivityDataSourceImpl @Inject constructor(
@@ -16,6 +17,14 @@ class ActivityDataSourceImpl @Inject constructor(
         emit(
             BitgoeulApiHandler<Unit>()
                 .httpRequest { activityAPI.addStudentActivityInfo(body = body) }
+                .sendRequest()
+        )
+    }.flowOn(Dispatchers.IO)
+
+    override suspend fun editStudentActivityInfo(id: UUID, body: StudentActivityModel): Flow<Unit> = flow {
+        emit(
+            BitgoeulApiHandler<Unit>()
+                .httpRequest { activityAPI.editStudentActivityInfo(id = id, body = body) }
                 .sendRequest()
         )
     }.flowOn(Dispatchers.IO)


### PR DESCRIPTION
## 💡 개요
학생활동정보수정 네트워크 세팅
## 📃 작업내용
-  add editStudentActivity fun in ActivityAPI
- add editStudentActivityInfo fun in ActivityDataSource
- add editStudentActivityInfo fun in ActivityRepository
- add EditStudentActivityInfoUseCase