### PR TITLE
🔀 :: (#72) - Set up network on reject student activity info

### DIFF
--- a/core/data/src/main/java/com/msg/data/repository/activity/ActivityRepository.kt
+++ b/core/data/src/main/java/com/msg/data/repository/activity/ActivityRepository.kt
@@ -9,4 +9,5 @@ interface ActivityRepository {
     suspend fun addStudentActivityInfo(body: StudentActivityModel): Flow<Unit>
     suspend fun editStudentActivityInfo(id: UUID, body: StudentActivityModel): Flow<Unit>
     suspend fun approveStudentActivityInfo(id: UUID): Flow<Unit>
+    suspend fun rejectStudentActivityInfo(id: UUID): Flow<Unit>
 }

--- a/core/data/src/main/java/com/msg/data/repository/activity/ActivityRepositoryImpl.kt
+++ b/core/data/src/main/java/com/msg/data/repository/activity/ActivityRepositoryImpl.kt
@@ -27,4 +27,10 @@ class ActivityRepositoryImpl @Inject constructor(
             id = id
         )
     }
+
+    override suspend fun rejectStudentActivityInfo(id: UUID): Flow<Unit> {
+        return activityDataSource.rejectStudentActivityInfo(
+            id = id
+        )
+    }
 }

--- a/core/domain/src/main/java/com/msg/domain/activity/RejectStudentActivityInfoUseCase.kt
+++ b/core/domain/src/main/java/com/msg/domain/activity/RejectStudentActivityInfoUseCase.kt
@@ -1,0 +1,13 @@
+package com.msg.domain.activity
+
+import com.msg.data.repository.activity.ActivityRepository
+import java.util.UUID
+import javax.inject.Inject
+
+class RejectStudentActivityInfoUseCase @Inject constructor(
+    private val activityRepository: ActivityRepository
+) {
+    suspend operator fun invoke(id: UUID) = runCatching {
+        activityRepository.rejectStudentActivityInfo(id = id)
+    }
+}

--- a/core/network/src/main/java/com/msg/network/api/ActivityAPI.kt
+++ b/core/network/src/main/java/com/msg/network/api/ActivityAPI.kt
@@ -23,4 +23,9 @@ interface ActivityAPI {
     suspend fun approveStudentActivityInfo(
         @Path("id") id: UUID
     )
+
+    @PATCH("activity/{id}/reject")
+    suspend fun rejectStudentActivityInfo(
+        @Path("id") id: UUID
+    )
 }

--- a/core/network/src/main/java/com/msg/network/datasource/activity/ActivityDataSource.kt
+++ b/core/network/src/main/java/com/msg/network/datasource/activity/ActivityDataSource.kt
@@ -8,4 +8,5 @@ interface ActivityDataSource {
     suspend fun addStudentActivityInfo(body: StudentActivityModel): Flow<Unit>
     suspend fun editStudentActivityInfo(id: UUID, body: StudentActivityModel): Flow<Unit>
     suspend fun approveStudentActivityInfo(id: UUID): Flow<Unit>
+    suspend fun rejectStudentActivityInfo(id: UUID): Flow<Unit>
 }

--- a/core/network/src/main/java/com/msg/network/datasource/activity/ActivityDataSourceImpl.kt
+++ b/core/network/src/main/java/com/msg/network/datasource/activity/ActivityDataSourceImpl.kt
@@ -36,4 +36,12 @@ class ActivityDataSourceImpl @Inject constructor(
                 .sendRequest()
         )
     }.flowOn(Dispatchers.IO)
+
+    override suspend fun rejectStudentActivityInfo(id: UUID): Flow<Unit> = flow {
+        emit(
+            BitgoeulApiHandler<Unit>()
+                .httpRequest { activityAPI.rejectStudentActivityInfo(id = id) }
+                .sendRequest()
+        )
+    }.flowOn(Dispatchers.IO)
 }


### PR DESCRIPTION
## 💡 개요
학생활동정보거절 및 삭제 네트워크 세팅
## 📃 작업내용
- add rejectStudentActivityInfo fun in ActivityAPI
- add rejectStudentActivityInfo fun in ActivityDataSource
- add rejectStudentActivityInfo fun in ActivityRepository
- add RejectStudentActivityInfoUseCase