### PR TITLE
🔀 :: (#74) - Set up network on delete student activity info

### DIFF
--- a/core/data/src/main/java/com/msg/data/repository/activity/ActivityRepository.kt
+++ b/core/data/src/main/java/com/msg/data/repository/activity/ActivityRepository.kt
@@ -10,4 +10,5 @@ interface ActivityRepository {
     suspend fun editStudentActivityInfo(id: UUID, body: StudentActivityModel): Flow<Unit>
     suspend fun approveStudentActivityInfo(id: UUID): Flow<Unit>
     suspend fun rejectStudentActivityInfo(id: UUID): Flow<Unit>
+    suspend fun deleteStudentActivityInfo(id: UUID): Flow<Unit>
 }

--- a/core/data/src/main/java/com/msg/data/repository/activity/ActivityRepositoryImpl.kt
+++ b/core/data/src/main/java/com/msg/data/repository/activity/ActivityRepositoryImpl.kt
@@ -33,4 +33,10 @@ class ActivityRepositoryImpl @Inject constructor(
             id = id
         )
     }
+
+    override suspend fun deleteStudentActivityInfo(id: UUID): Flow<Unit> {
+        return activityDataSource.deleteStudentActivityInfo(
+            id = id
+        )
+    }
 }

--- a/core/domain/src/main/java/com/msg/domain/activity/DeleteStudentActivityInfoUseCase.kt
+++ b/core/domain/src/main/java/com/msg/domain/activity/DeleteStudentActivityInfoUseCase.kt
@@ -1,0 +1,13 @@
+package com.msg.domain.activity
+
+import com.msg.data.repository.activity.ActivityRepository
+import java.util.UUID
+import javax.inject.Inject
+
+class DeleteStudentActivityInfoUseCase @Inject constructor(
+    private val activityRepository: ActivityRepository
+) {
+    suspend operator fun invoke(id: UUID) = runCatching {
+        activityRepository.deleteStudentActivityInfo(id = id)
+    }
+}

--- a/core/network/src/main/java/com/msg/network/api/ActivityAPI.kt
+++ b/core/network/src/main/java/com/msg/network/api/ActivityAPI.kt
@@ -2,6 +2,7 @@ package com.msg.network.api
 
 import com.msg.model.remote.model.activity.StudentActivityModel
 import retrofit2.http.Body
+import retrofit2.http.DELETE
 import retrofit2.http.PATCH
 import retrofit2.http.POST
 import retrofit2.http.Path
@@ -24,8 +25,13 @@ interface ActivityAPI {
         @Path("id") id: UUID
     )
 
-    @PATCH("activity/{id}/reject")
+    @DELETE("activity/{id}/reject")
     suspend fun rejectStudentActivityInfo(
+        @Path("id") id: UUID
+    )
+
+    @DELETE("activity/{id}")
+    suspend fun deleteStudentActivityInfo(
         @Path("id") id: UUID
     )
 }

--- a/core/network/src/main/java/com/msg/network/datasource/activity/ActivityDataSource.kt
+++ b/core/network/src/main/java/com/msg/network/datasource/activity/ActivityDataSource.kt
@@ -9,4 +9,5 @@ interface ActivityDataSource {
     suspend fun editStudentActivityInfo(id: UUID, body: StudentActivityModel): Flow<Unit>
     suspend fun approveStudentActivityInfo(id: UUID): Flow<Unit>
     suspend fun rejectStudentActivityInfo(id: UUID): Flow<Unit>
+    suspend fun deleteStudentActivityInfo(id: UUID): Flow<Unit>
 }

--- a/core/network/src/main/java/com/msg/network/datasource/activity/ActivityDataSourceImpl.kt
+++ b/core/network/src/main/java/com/msg/network/datasource/activity/ActivityDataSourceImpl.kt
@@ -44,4 +44,12 @@ class ActivityDataSourceImpl @Inject constructor(
                 .sendRequest()
         )
     }.flowOn(Dispatchers.IO)
+
+    override suspend fun deleteStudentActivityInfo(id: UUID): Flow<Unit> = flow {
+        emit(
+            BitgoeulApiHandler<Unit>()
+                .httpRequest { activityAPI.deleteStudentActivityInfo(id = id) }
+                .sendRequest()
+        )
+    }.flowOn(Dispatchers.IO)
 }


### PR DESCRIPTION
## 💡 개요
학생활동정보 삭제 네트워크 세팅
## 📃 작업내용
- add deleteStudentActivityInfo fun in ActivityAPI
- add deleteStudentActivityInfo fun in ActivityDataSource
- add deleteStudentActivityInfo fun in ActivityRepository
- add DeleteStudentActivityInfoUseCase