### PR TITLE
🔀 :: (#80) - Set up network on inquiry entire student activity info list

### DIFF
--- a/core/data/src/main/java/com/msg/data/repository/activity/ActivityRepository.kt
+++ b/core/data/src/main/java/com/msg/data/repository/activity/ActivityRepository.kt
@@ -1,5 +1,6 @@
 package com.msg.data.repository.activity
 
+import com.msg.model.remote.model.activity.InquiryStudentActivityModel
 import com.msg.model.remote.model.activity.StudentActivityModel
 import com.msg.model.remote.response.activity.InquiryStudentActivityListResponse
 import kotlinx.coroutines.flow.Flow
@@ -14,4 +15,5 @@ interface ActivityRepository {
     suspend fun deleteStudentActivityInfo(id: UUID): Flow<Unit>
     suspend fun inquiryMyStudentActivityInfoList(page: Int, size: Int, sort: String): Flow<InquiryStudentActivityListResponse>
     suspend fun inquiryStudentActivityInfoList(page: Int, size: Int, sort: String, id: UUID): Flow<InquiryStudentActivityListResponse>
+    suspend fun inquiryEntireStudentActivityInfoList(page: Int, size: Int, sort: String): Flow<InquiryStudentActivityListResponse>
 }

--- a/core/data/src/main/java/com/msg/data/repository/activity/ActivityRepositoryImpl.kt
+++ b/core/data/src/main/java/com/msg/data/repository/activity/ActivityRepositoryImpl.kt
@@ -1,5 +1,6 @@
 package com.msg.data.repository.activity
 
+import com.msg.model.remote.model.activity.InquiryStudentActivityModel
 import com.msg.model.remote.model.activity.StudentActivityModel
 import com.msg.model.remote.response.activity.InquiryStudentActivityListResponse
 import com.msg.network.datasource.activity.ActivityDataSource
@@ -64,6 +65,18 @@ class ActivityRepositoryImpl @Inject constructor(
             size = size,
             sort = sort,
             id = id
+        )
+    }
+
+    override suspend fun inquiryEntireStudentActivityInfoList(
+        page: Int,
+        size: Int,
+        sort: String
+    ): Flow<InquiryStudentActivityListResponse> {
+        return activityDataSource.inquiryEntireStudentActivityInfoList(
+            page = page,
+            size = size,
+            sort = sort
         )
     }
 }

--- a/core/domain/src/main/java/com/msg/domain/activity/InquiryEntireStudentActivityInfoListUseCase.kt
+++ b/core/domain/src/main/java/com/msg/domain/activity/InquiryEntireStudentActivityInfoListUseCase.kt
@@ -1,0 +1,16 @@
+package com.msg.domain.activity
+
+import com.msg.data.repository.activity.ActivityRepository
+import javax.inject.Inject
+
+class InquiryEntireStudentActivityInfoListUseCase @Inject constructor(
+    private val activityRepository: ActivityRepository
+) {
+    suspend operator fun invoke(page: Int, size: Int, sort: String) = runCatching {
+        activityRepository.inquiryEntireStudentActivityInfoList(
+            page = page,
+            size = size,
+            sort = sort
+        )
+    }
+}

--- a/core/network/src/main/java/com/msg/network/api/ActivityAPI.kt
+++ b/core/network/src/main/java/com/msg/network/api/ActivityAPI.kt
@@ -52,4 +52,11 @@ interface ActivityAPI {
         @Query("sort") sort: String,
         @Path("student_id") id: UUID
     ): InquiryStudentActivityListResponse
+
+    @GET("activity")
+    suspend fun inquiryEntireStudentActivityInfoList(
+        @Query("page") page: Int,
+        @Query("size") size: Int,
+        @Query("sort") sort: String
+    ): InquiryStudentActivityListResponse
 }

--- a/core/network/src/main/java/com/msg/network/datasource/activity/ActivityDataSource.kt
+++ b/core/network/src/main/java/com/msg/network/datasource/activity/ActivityDataSource.kt
@@ -13,4 +13,5 @@ interface ActivityDataSource {
     suspend fun deleteStudentActivityInfo(id: UUID): Flow<Unit>
     suspend fun inquiryMyStudentActivityInfoList(page: Int, size: Int, sort: String): Flow<InquiryStudentActivityListResponse>
     suspend fun inquiryStudentActivityInfoList(page: Int, size: Int, sort: String, id: UUID): Flow<InquiryStudentActivityListResponse>
+    suspend fun inquiryEntireStudentActivityInfoList(page: Int, size: Int, sort: String): Flow<InquiryStudentActivityListResponse>
 }

--- a/core/network/src/main/java/com/msg/network/datasource/activity/ActivityDataSourceImpl.kt
+++ b/core/network/src/main/java/com/msg/network/datasource/activity/ActivityDataSourceImpl.kt
@@ -78,4 +78,16 @@ class ActivityDataSourceImpl @Inject constructor(
                 .sendRequest()
         )
     }.flowOn(Dispatchers.IO)
+
+    override suspend fun inquiryEntireStudentActivityInfoList(
+        page: Int,
+        size: Int,
+        sort: String
+    ): Flow<InquiryStudentActivityListResponse> = flow {
+        emit(
+            BitgoeulApiHandler<InquiryStudentActivityListResponse>()
+                .httpRequest { activityAPI.inquiryEntireStudentActivityInfoList(page = page, size = size, sort = sort) }
+                .sendRequest()
+        )
+    }.flowOn(Dispatchers.IO)
 }


### PR DESCRIPTION
## 💡 개요
전체 학생 활동 리스트 조회 네트워크 세팅
## 📃 작업내용
- :memo: add inquiryEntireStudentActivityInfoList fun in ActivityAPI
- :memo: add inquiryEntireStudentActivityInfoList fun in ActivityDataSource
- :memo: add inquiryEntireStudentActivityInfoList fun in ActivityRepository
- :memo: add InquiryEntireStudentActivityInfoListUseCase