### PR TITLE
🔀 :: (#65) - Lock screen rotate

### DIFF
--- a/core/design-system/src/main/java/com/msg/design_system/util/LockScreenOrientation.kt
+++ b/core/design-system/src/main/java/com/msg/design_system/util/LockScreenOrientation.kt
@@ -1,0 +1,27 @@
+package com.msg.design_system.util
+
+import android.app.Activity
+import android.content.Context
+import android.content.ContextWrapper
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.DisposableEffect
+import androidx.compose.ui.platform.LocalContext
+
+@Composable
+fun LockScreenOrientation(orientation: Int) {
+    val context = LocalContext.current
+    DisposableEffect(orientation) {
+        val activity = context.findActivity() ?: return@DisposableEffect onDispose {}
+        val originalOrientation = orientation
+        activity.requestedOrientation = orientation
+        onDispose {
+            activity.requestedOrientation = originalOrientation
+        }
+    }
+}
+
+fun Context.findActivity(): Activity? = when (this) {
+    is Activity -> this
+    is ContextWrapper -> baseContext.findActivity()
+    else -> null
+}

--- a/feature/login/src/main/java/com/bitgoeul/login/LoginScreen.kt
+++ b/feature/login/src/main/java/com/bitgoeul/login/LoginScreen.kt
@@ -1,5 +1,6 @@
 package com.bitgoeul.login
 
+import android.content.pm.ActivityInfo
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Row
@@ -28,6 +29,7 @@ import com.msg.design_system.component.textfield.DefaultTextField
 import com.msg.design_system.component.textfield.LinkText
 import com.msg.design_system.component.textfield.PasswordTextField
 import com.msg.design_system.theme.BitgoeulAndroidTheme
+import com.msg.design_system.util.LockScreenOrientation
 import com.msg.model.remote.request.auth.LoginRequest
 
 @Composable
@@ -41,6 +43,7 @@ fun LoginRoute(
 fun LoginScreen(
     onSignUpClick: () -> Unit
 ) {
+    LockScreenOrientation(orientation = ActivityInfo.SCREEN_ORIENTATION_PORTRAIT)
     val isEmailErrorStatus = remember { mutableStateOf(false) }
     val isPasswordErrorStatus = remember { mutableStateOf(false) }
     val isErrorTextShow = remember { mutableStateOf(false) }

--- a/feature/sign-up/src/main/java/com/msg/sign_up/SignUpScreen.kt
+++ b/feature/sign-up/src/main/java/com/msg/sign_up/SignUpScreen.kt
@@ -1,5 +1,6 @@
 package com.msg.sign_up
 
+import android.content.pm.ActivityInfo
 import android.graphics.Rect
 import android.util.Log
 import android.view.ViewTreeObserver
@@ -32,6 +33,7 @@ import com.msg.design_system.component.textfield.DefaultTextField
 import com.msg.design_system.component.textfield.PasswordTextField
 import com.msg.design_system.component.topbar.GoBackTopBar
 import com.msg.design_system.theme.BitgoeulAndroidTheme
+import com.msg.design_system.util.LockScreenOrientation
 import com.msg.sign_up.SignUpState.*
 import com.msg.sign_up.component.SignUpBottomSheet
 import com.msg.sign_up.data.BelongList
@@ -102,6 +104,7 @@ fun SignUpRoute(
 fun SignUpScreen(
     onBackClick: () -> Unit
 ) {
+    LockScreenOrientation(orientation = ActivityInfo.SCREEN_ORIENTATION_PORTRAIT)
     val focusManager = LocalFocusManager.current
 
     val signUpState = remember { mutableStateOf(Belong) }


### PR DESCRIPTION
## 💡 개요
화면 회전 잠금 적용
## 📃 작업내용
- :sparkles: add LockScreenOrientation fun
- :memo: apply LockScreenOrientation 
## 🔀 변경사항
LoginScreen, SignUpScreen에 LockScreenOrientation 추가
## 🍴 사용방법
```kt
LockScreenOrientation(orientation = ActivityInfo.SCREEN_ORIENTATION_PORTRAIT // or SCREEN_ORIENTATION_LANDSCAPE
```