### PR TITLE
🔀 :: (#89) - Refactoring loginscreen for easier ui test

### DIFF
--- a/feature/login/src/main/java/com/bitgoeul/login/LoginScreen.kt
+++ b/feature/login/src/main/java/com/bitgoeul/login/LoginScreen.kt
@@ -34,14 +34,19 @@ import com.msg.model.remote.request.auth.LoginRequest
 
 @Composable
 fun LoginRoute(
-    onSignUpClick: () -> Unit
+    onSignUpClick: () -> Unit,
+    viewModel: AuthViewModel = hiltViewModel()
 ) {
-    LoginScreen(onSignUpClick = onSignUpClick)
+    LoginScreen(
+        onSignUpClick = onSignUpClick,
+        onLoginClick = { viewModel.login(LoginRequest(viewModel.email.value, viewModel.password.value)) }
+    )
 }
 
 @Composable
 fun LoginScreen(
-    onSignUpClick: () -> Unit
+    onSignUpClick: () -> Unit,
+    onLoginClick: () -> Unit = {}
 ) {
     LockScreenOrientation(orientation = ActivityInfo.SCREEN_ORIENTATION_PORTRAIT)
     val isEmailErrorStatus = remember { mutableStateOf(false) }
@@ -50,7 +55,6 @@ fun LoginScreen(
     var isTextStatus = ""
     val emailState = remember { mutableStateOf("") }
     val passwordState = remember { mutableStateOf("") }
-    val authViewModel: AuthViewModel = hiltViewModel()
     BitgoeulAndroidTheme { color, type ->
         Box {
             Column(
@@ -98,8 +102,7 @@ fun LoginScreen(
                         isLinked = false,
                         isDisabled = false,
                         isReadOnly = false,
-                        isReverseTrailingIcon = false,
-                        value = isTextStatus
+                        isReverseTrailingIcon = false
                     )
                 }
 
@@ -145,12 +148,7 @@ fun LoginScreen(
                             .height(52.dp),
                         state = ButtonState.Disable,
                     ) {
-                        authViewModel.login(
-                            body = LoginRequest(
-                                email = emailState.value,
-                                password = passwordState.value
-                            )
-                        )
+                        onLoginClick()
                     }
                 }
 

--- a/feature/login/src/main/java/com/bitgoeul/login/LoginScreen.kt
+++ b/feature/login/src/main/java/com/bitgoeul/login/LoginScreen.kt
@@ -16,6 +16,7 @@ import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.focus.onFocusChanged
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
@@ -39,14 +40,18 @@ fun LoginRoute(
 ) {
     LoginScreen(
         onSignUpClick = onSignUpClick,
-        onLoginClick = { viewModel.login(LoginRequest(viewModel.email.value, viewModel.password.value)) }
+        onLoginClick = { viewModel.login(LoginRequest(viewModel.email.value, viewModel.password.value)) },
+        saveLoginData = { email, password ->
+            viewModel.setLoginData(email = email, password = password)
+        }
     )
 }
 
 @Composable
 fun LoginScreen(
     onSignUpClick: () -> Unit,
-    onLoginClick: () -> Unit = {}
+    onLoginClick: () -> Unit = {},
+    saveLoginData: (String, String) -> Unit = { _,_ -> }
 ) {
     LockScreenOrientation(orientation = ActivityInfo.SCREEN_ORIENTATION_PORTRAIT)
     val isEmailErrorStatus = remember { mutableStateOf(false) }
@@ -148,6 +153,7 @@ fun LoginScreen(
                             .height(52.dp),
                         state = ButtonState.Disable,
                     ) {
+                        saveLoginData(emailState.value, passwordState.value)
                         onLoginClick()
                     }
                 }

--- a/feature/login/src/main/java/com/bitgoeul/login/viewmodel/AuthViewModel.kt
+++ b/feature/login/src/main/java/com/bitgoeul/login/viewmodel/AuthViewModel.kt
@@ -51,4 +51,9 @@ class AuthViewModel @Inject constructor(
             _loginRequest.value = it.errorHandling()
         }
     }
+
+    fun setLoginData(email: String, password: String) {
+        _email.value = email
+        _password.value = password
+    }
 }

--- a/feature/login/src/main/java/com/bitgoeul/login/viewmodel/AuthViewModel.kt
+++ b/feature/login/src/main/java/com/bitgoeul/login/viewmodel/AuthViewModel.kt
@@ -1,5 +1,7 @@
 package com.bitgoeul.login.viewmodel
 
+import androidx.compose.runtime.State
+import androidx.compose.runtime.mutableStateOf
 import androidx.lifecycle.LiveData
 import androidx.lifecycle.MutableLiveData
 import androidx.lifecycle.ViewModel
@@ -29,6 +31,12 @@ class AuthViewModel @Inject constructor(
 
     private val _loginRequest = MutableLiveData<Event<AuthTokenModel>>()
     val loginRequest: LiveData<Event<AuthTokenModel>> get() = _loginRequest
+
+    private val _email = mutableStateOf("")
+    val email: State<String> = _email
+
+    private val _password = mutableStateOf("")
+    val password: State<String> = _password
 
     fun login(body: LoginRequest) = viewModelScope.launch {
         loginUseCase(


### PR DESCRIPTION
## 💡 개요
로그인 스크린에서의 UI 테스트롤 쉽게 하기 위한 리팩토링
## 📃 작업내용
- 기존 LoginScreen 함수에서 이뤄지던 ViewModel과의 통신을 LoginRoute함수로 옮김
## 🔀 변경사항
LoginScreen 내부에서 ViewModel을 호출하지 않음
LoginRoute에서 AuthViewModel을 호출하여 통신 진행