### PR TITLE
🔀 :: (#88) - Fix title text in LoginScreen

### DIFF
--- a/feature/login/src/main/java/com/bitgoeul/login/LoginScreen.kt
+++ b/feature/login/src/main/java/com/bitgoeul/login/LoginScreen.kt
@@ -73,9 +73,7 @@ fun LoginScreen(
                 ) {
                     Spacer(modifier = Modifier.width(28.dp))
                     Text(
-                        modifier = Modifier
-                            .width(104.dp)
-                            .height(108.dp),
+                        modifier = Modifier,
                         text = stringResource(id = R.string.project_name),
                         color = color.BLACK,
                         style = type.titleLarge,


### PR DESCRIPTION
## 💡 개요
LoginScreen의 TitleText가 의도한 대로 보이지 않는 이슈 해결
## 📃 작업내용
- :fire: delete width, height