### PR TITLE
🔀 :: (#106) Change LectureUseCase kotlin.runCatching

### DIFF
--- a/core/domain/src/main/java/com/msg/domain/lecture/ApprovePendingLectureUseCase.kt
+++ b/core/domain/src/main/java/com/msg/domain/lecture/ApprovePendingLectureUseCase.kt
@@ -7,7 +7,7 @@ import javax.inject.Inject
 class ApprovePendingLectureUseCase @Inject constructor(
     private val lectureRepository: LectureRepository
 ) {
-    suspend operator fun invoke(id: UUID) = kotlin.runCatching {
+    suspend operator fun invoke(id: UUID) = runCatching {
         lectureRepository.approvePendingLecture(id = id)
     }
 }

--- a/core/domain/src/main/java/com/msg/domain/lecture/GetDetailLectureUseCase.kt
+++ b/core/domain/src/main/java/com/msg/domain/lecture/GetDetailLectureUseCase.kt
@@ -7,7 +7,7 @@ import javax.inject.Inject
 class GetDetailLectureUseCase @Inject constructor(
     private val lectureRepository: LectureRepository
 ) {
-    suspend operator fun invoke(id: UUID) = kotlin.runCatching {
+    suspend operator fun invoke(id: UUID) = runCatching {
         lectureRepository.getDetailLecture(id = id)
     }
 }

--- a/core/domain/src/main/java/com/msg/domain/lecture/GetLectureListUseCase.kt
+++ b/core/domain/src/main/java/com/msg/domain/lecture/GetLectureListUseCase.kt
@@ -6,7 +6,7 @@ import javax.inject.Inject
 class GetLectureListUseCase @Inject constructor(
     private val lectureRepository: LectureRepository
 ) {
-    suspend operator fun invoke() = kotlin.runCatching {
+    suspend operator fun invoke() = runCatching {
         lectureRepository.getLectureList()
     }
 }

--- a/core/domain/src/main/java/com/msg/domain/lecture/LectureApplicationUseCase.kt
+++ b/core/domain/src/main/java/com/msg/domain/lecture/LectureApplicationUseCase.kt
@@ -7,7 +7,7 @@ import javax.inject.Inject
 class LectureApplicationUseCase @Inject constructor(
     private val lectureRepository: LectureRepository
 ) {
-    suspend operator fun invoke(id: UUID) = kotlin.runCatching {
+    suspend operator fun invoke(id: UUID) = runCatching {
         lectureRepository.lectureApplication(id = id)
     }
 }

--- a/core/domain/src/main/java/com/msg/domain/lecture/OpenLectureUseCase.kt
+++ b/core/domain/src/main/java/com/msg/domain/lecture/OpenLectureUseCase.kt
@@ -7,7 +7,7 @@ import javax.inject.Inject
 class OpenLectureUseCase @Inject constructor(
     private val lectureRepository: LectureRepository,
 ) {
-    suspend operator fun invoke(body: OpenLectureRequest) = kotlin.runCatching {
+    suspend operator fun invoke(body: OpenLectureRequest) = runCatching {
         lectureRepository.openLecture(body = body)
     }
 }

--- a/core/domain/src/main/java/com/msg/domain/lecture/RejectPendingLecture.kt
+++ b/core/domain/src/main/java/com/msg/domain/lecture/RejectPendingLecture.kt
@@ -7,7 +7,7 @@ import javax.inject.Inject
 class RejectPendingLecture @Inject constructor(
     private val lectureRepository: LectureRepository
 ) {
-    suspend operator fun invoke(id: UUID) = kotlin.runCatching {
+    suspend operator fun invoke(id: UUID) = runCatching {
         lectureRepository.rejectPendingLecture(id = id)
     }
 }

--- a/core/domain/src/main/java/com/msg/domain/lecture/RejectPendingLectureUseCase.kt
+++ b/core/domain/src/main/java/com/msg/domain/lecture/RejectPendingLectureUseCase.kt
@@ -4,7 +4,7 @@ import com.msg.data.repository.lecture.LectureRepository
 import java.util.UUID
 import javax.inject.Inject
 
-class RejectPendingLecture @Inject constructor(
+class RejectPendingLectureUseCase @Inject constructor(
     private val lectureRepository: LectureRepository
 ) {
     suspend operator fun invoke(id: UUID) = runCatching {


### PR DESCRIPTION
## 💡 개요
컨벤션을 맞추기 위해 LectureUseCase들의 kotlin.runCatching을 runCatching으로 변경했어야함

## 📃 작업내용
RejectPendingLectureUseCase
ApprovePendingLectureUseCase
GetDetailLectureUseCase
GetLectureListUseCase
LectureApplicationUseCase
OpenLectureUseCase
위의 UseCase의 invoke 함수 kotlin.runCatching을 삭제 후 runCatching으로 변경함

## 🔀 변경사항
RejectPendingLectureUseCase
ApprovePendingLectureUseCase
GetDetailLectureUseCase
GetLectureListUseCase
LectureApplicationUseCase
OpenLectureUseCase
위의 UseCase의 invoke 함수의 runCatching

RejectPendingLecture클래스의 네이밍이 RejectPendingLectureUseCase로 바뀜
