### PR TITLE
🔀 :: (#112) - Save authority in local when login

### DIFF
--- a/core/data/src/main/java/com/msg/data/repository/auth/AuthRepositoryImpl.kt
+++ b/core/data/src/main/java/com/msg/data/repository/auth/AuthRepositoryImpl.kt
@@ -29,6 +29,7 @@ class AuthRepositoryImpl @Inject constructor(
             localDataSource.setAccessTokenExp(it.accessExpiredAt)
             localDataSource.setRefreshToken(it.refreshToken)
             localDataSource.setRefreshTokenExp(it.refreshExpiredAt)
+            localDataSource.setAuthority(it.authority)
         }
     }
 

--- a/core/datastore/src/main/java/com/msg/datastore/AuthTokenDataSource.kt
+++ b/core/datastore/src/main/java/com/msg/datastore/AuthTokenDataSource.kt
@@ -1,6 +1,7 @@
 package com.msg.datastore
 
 import androidx.datastore.core.DataStore
+import com.msg.model.remote.enumdatatype.Authority
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.map
 import javax.inject.Inject
@@ -52,6 +53,18 @@ class AuthTokenDataSource @Inject constructor(
         authToken.updateData {
             it.toBuilder()
                 .setRefreshToken(refreshTokenExp)
+                .build()
+        }
+    }
+
+    suspend fun getAuthority(): Flow<String> = authToken.data.map {
+        it.authority ?: ""
+    }
+
+    suspend fun setAuthority(authority: Authority) {
+        authToken.updateData {
+            it.toBuilder()
+                .setAuthority(authority.toString())
                 .build()
         }
     }

--- a/core/datastore/src/main/proto/authToken.proto
+++ b/core/datastore/src/main/proto/authToken.proto
@@ -8,4 +8,5 @@ message AuthToken {
   string accessExp = 2;
   string refreshToken = 3;
   string refreshExp = 4;
+  string authority = 5;
 }

--- a/core/model/src/main/java/com/msg/model/remote/model/auth/AuthTokenModel.kt
+++ b/core/model/src/main/java/com/msg/model/remote/model/auth/AuthTokenModel.kt
@@ -1,9 +1,12 @@
 package com.msg.model.remote.model.auth
 
+import com.msg.model.remote.enumdatatype.Authority
+
 
 data class AuthTokenModel(
     val accessToken: String,
     val refreshToken: String,
     val accessExpiredAt: String,
     val refreshExpiredAt: String,
+    val authority: Authority
 )


### PR DESCRIPTION
## 💡 개요
protobuf를 사용하여 로그인 시 authority를 로컬에 저장하는 로직을 구현
## 📃 작업내용
- :sparkles: save authority when login with protobuf