### PR TITLE
🔀 :: (#165) Find Password Network Setting

### DIFF
--- a/core/data/src/main/java/com/msg/data/repository/auth/AuthRepository.kt
+++ b/core/data/src/main/java/com/msg/data/repository/auth/AuthRepository.kt
@@ -1,6 +1,7 @@
 package com.msg.data.repository.auth
 
 import com.msg.model.remote.model.auth.AuthTokenModel
+import com.msg.model.remote.request.auth.FindPasswordRequest
 import com.msg.model.remote.request.auth.LoginRequest
 import com.msg.model.remote.request.auth.SignUpBbozzakTeacherRequest
 import com.msg.model.remote.request.auth.SignUpCompanyInstructorRequest
@@ -19,6 +20,7 @@ interface AuthRepository {
     suspend fun signUpGovernment(body: SignUpGovernmentRequest): Flow<Unit>
     suspend fun signUpCompanyInstructor(body: SignUpCompanyInstructorRequest): Flow<Unit>
     suspend fun signUpBbozzakTeacher(body: SignUpBbozzakTeacherRequest): Flow<Unit>
+    suspend fun findPassword(body: FindPasswordRequest): Flow<Unit>
     suspend fun logout(): Flow<Unit>
     suspend fun withdraw(): Flow<Unit>
 }

--- a/core/data/src/main/java/com/msg/data/repository/auth/AuthRepositoryImpl.kt
+++ b/core/data/src/main/java/com/msg/data/repository/auth/AuthRepositoryImpl.kt
@@ -2,6 +2,7 @@ package com.msg.data.repository.auth
 
 import com.msg.datastore.AuthTokenDataSource
 import com.msg.model.remote.model.auth.AuthTokenModel
+import com.msg.model.remote.request.auth.FindPasswordRequest
 import com.msg.model.remote.request.auth.LoginRequest
 import com.msg.model.remote.request.auth.SignUpBbozzakTeacherRequest
 import com.msg.model.remote.request.auth.SignUpCompanyInstructorRequest
@@ -69,6 +70,11 @@ class AuthRepositoryImpl @Inject constructor(
         )
     }
 
+    override suspend fun findPassword(body: FindPasswordRequest): Flow<Unit> {
+        return authDataSource.findPassword(
+            body = body
+        )
+    }
     override suspend fun logout(): Flow<Unit> {
         return authDataSource.logout()
     }

--- a/core/domain/src/main/java/com/msg/domain/auth/FindPasswordUseCase.kt
+++ b/core/domain/src/main/java/com/msg/domain/auth/FindPasswordUseCase.kt
@@ -1,0 +1,13 @@
+package com.msg.domain.auth
+
+import com.msg.data.repository.auth.AuthRepository
+import com.msg.model.remote.request.auth.FindPasswordRequest
+import javax.inject.Inject
+
+class FindPasswordUseCase @Inject constructor(
+    private val authRepository: AuthRepository
+){
+    suspend operator fun invoke(body: FindPasswordRequest) = runCatching {
+        authRepository.findPassword(body = body)
+    }
+}

--- a/core/model/src/main/java/com/msg/model/remote/request/auth/FindPasswordRequest.kt
+++ b/core/model/src/main/java/com/msg/model/remote/request/auth/FindPasswordRequest.kt
@@ -1,0 +1,6 @@
+package com.msg.model.remote.request.auth
+
+data class FindPasswordRequest(
+    val email: String,
+    val newPassword: String, // 8 ~ 24 영어(대문자 소문자 상관 X) + 숫자 + 특수 문자(여러 개도 상관 X)
+)

--- a/core/network/src/main/java/com/msg/network/api/AuthAPI.kt
+++ b/core/network/src/main/java/com/msg/network/api/AuthAPI.kt
@@ -1,6 +1,7 @@
 package com.msg.network.api
 
 import com.msg.model.remote.model.auth.AuthTokenModel
+import com.msg.model.remote.request.auth.FindPasswordRequest
 import com.msg.model.remote.request.auth.LoginRequest
 import com.msg.model.remote.request.auth.SignUpBbozzakTeacherRequest
 import com.msg.model.remote.request.auth.SignUpCompanyInstructorRequest
@@ -10,6 +11,7 @@ import com.msg.model.remote.request.auth.SignUpProfessorRequest
 import com.msg.model.remote.request.auth.SignUpStudentRequest
 import retrofit2.http.Body
 import retrofit2.http.DELETE
+import retrofit2.http.PATCH
 import retrofit2.http.POST
 
 interface AuthAPI {
@@ -46,6 +48,11 @@ interface AuthAPI {
     @POST("auth/bbozzak")
     suspend fun signUpBbozzakTeacher(
         @Body body: SignUpBbozzakTeacherRequest
+    )
+
+    @PATCH("auth/password")
+    suspend fun findPassword(
+        @Body body: FindPasswordRequest // newPassword -> 8 ~ 24 영어(대문자 소문자 상관 X) + 숫자 + 특수 문자(여러 개도 상관 X)
     )
 
     @DELETE("auth")

--- a/core/network/src/main/java/com/msg/network/datasource/auth/AuthDataSource.kt
+++ b/core/network/src/main/java/com/msg/network/datasource/auth/AuthDataSource.kt
@@ -1,6 +1,7 @@
 package com.msg.network.datasource.auth
 
 import com.msg.model.remote.model.auth.AuthTokenModel
+import com.msg.model.remote.request.auth.FindPasswordRequest
 import com.msg.model.remote.request.auth.LoginRequest
 import com.msg.model.remote.request.auth.SignUpBbozzakTeacherRequest
 import com.msg.model.remote.request.auth.SignUpCompanyInstructorRequest
@@ -18,6 +19,7 @@ interface AuthDataSource {
     suspend fun signUpGovernment(body: SignUpGovernmentRequest): Flow<Unit>
     suspend fun signUpCompanyInstructor(body: SignUpCompanyInstructorRequest): Flow<Unit>
     suspend fun signUpBbozzakTeacher(body: SignUpBbozzakTeacherRequest): Flow<Unit>
+    suspend fun findPassword(body: FindPasswordRequest): Flow<Unit>
     suspend fun logout(): Flow<Unit>
     suspend fun withdraw(): Flow<Unit>
 }

--- a/core/network/src/main/java/com/msg/network/datasource/auth/AuthDataSourceImpl.kt
+++ b/core/network/src/main/java/com/msg/network/datasource/auth/AuthDataSourceImpl.kt
@@ -1,6 +1,7 @@
 package com.msg.network.datasource.auth
 
 import com.msg.model.remote.model.auth.AuthTokenModel
+import com.msg.model.remote.request.auth.FindPasswordRequest
 import com.msg.model.remote.request.auth.LoginRequest
 import com.msg.model.remote.request.auth.SignUpBbozzakTeacherRequest
 import com.msg.model.remote.request.auth.SignUpCompanyInstructorRequest
@@ -72,6 +73,14 @@ class AuthDataSourceImpl @Inject constructor(
         emit(
             BitgoeulApiHandler<Unit>()
                 .httpRequest { authAPI.signUpBbozzakTeacher(body = body) }
+                .sendRequest()
+        )
+    }.flowOn(Dispatchers.IO)
+
+    override suspend fun findPassword(body: FindPasswordRequest): Flow<Unit> = flow {
+        emit(
+            BitgoeulApiHandler<Unit>()
+                .httpRequest { authAPI.findPassword(body = body) }
                 .sendRequest()
         )
     }.flowOn(Dispatchers.IO)


### PR DESCRIPTION
## 💡 개요
추가된 비밀번호 찾기 API의 네트워크를 세팅합니다.
## 📃 작업내용
AuthAPI에 findPassword suspend fun 추가
AuthDataSource에 findPassword suspend fun 추가
AuthRepository에 findPassword suspend fun 추가
FindPasswordUseCase 작성
## 🔀 변경사항
AuthAPI에 findPassword suspend fun 추가 되었습니다.
AuthDataSource에 findPassword suspend fun 추가 되었습니다.
AuthRepository에 findPassword suspend fun 추가 되었습니다.
## 🙋‍♂️ 질문사항
제가 빼먹은 부분이 있거나 컨벤션에 맞지 않는 부분이 있다면 알려주세요.
