### PR TITLE
🔀 :: (#167) Email Domain Network Setting

### DIFF
--- a/core/data/src/main/java/com/msg/data/di/RepositoryModule.kt
+++ b/core/data/src/main/java/com/msg/data/di/RepositoryModule.kt
@@ -10,6 +10,8 @@ import com.msg.data.repository.certification.CertificationRepository
 import com.msg.data.repository.certification.CertificationRepositoryImpl
 import com.msg.data.repository.club.ClubRepository
 import com.msg.data.repository.club.ClubRepositoryImpl
+import com.msg.data.repository.email.EmailRepository
+import com.msg.data.repository.email.EmailRepositoryImpl
 import com.msg.data.repository.faq.FaqRepository
 import com.msg.data.repository.faq.FaqRepositoryImpl
 import com.msg.data.repository.lecture.LectureRepository
@@ -70,4 +72,9 @@ abstract class RepositoryModule {
     abstract fun bindPostRepository(
         postRepositoryImpl: PostRepositoryImpl
     ): PostRepository
+
+    @Binds
+    abstract fun bindEmailRepository(
+        emailRepositoryImpl: EmailRepositoryImpl
+    ): EmailRepository
 }

--- a/core/data/src/main/java/com/msg/data/repository/email/EmailRepository.kt
+++ b/core/data/src/main/java/com/msg/data/repository/email/EmailRepository.kt
@@ -1,0 +1,10 @@
+package com.msg.data.repository.email
+
+import com.msg.model.remote.request.email.SendLinkToEmailRequest
+import com.msg.model.remote.response.email.GetEmailAuthenticateStatusResponse
+import kotlinx.coroutines.flow.Flow
+
+interface EmailRepository {
+    suspend fun sendLinkToEmail(body: SendLinkToEmailRequest): Flow<Unit>
+    suspend fun getEmailAuthenticateStatus(email: String): Flow<GetEmailAuthenticateStatusResponse>
+}

--- a/core/data/src/main/java/com/msg/data/repository/email/EmailRepositoryImpl.kt
+++ b/core/data/src/main/java/com/msg/data/repository/email/EmailRepositoryImpl.kt
@@ -1,0 +1,23 @@
+package com.msg.data.repository.email
+
+import com.msg.model.remote.request.email.SendLinkToEmailRequest
+import com.msg.model.remote.response.email.GetEmailAuthenticateStatusResponse
+import com.msg.network.datasource.email.EmailDataSource
+import kotlinx.coroutines.flow.Flow
+import javax.inject.Inject
+
+class EmailRepositoryImpl @Inject constructor(
+    private val emailDataSource: EmailDataSource
+) : EmailRepository {
+    override suspend fun sendLinkToEmail(body: SendLinkToEmailRequest): Flow<Unit> {
+        return emailDataSource.sendLinkToEmail(
+            body = body
+        )
+    }
+
+    override suspend fun getEmailAuthenticateStatus(email: String): Flow<GetEmailAuthenticateStatusResponse> {
+        return emailDataSource.getEmailAuthenticateStatus(
+            email = email
+        )
+    }
+}

--- a/core/domain/src/main/java/com/msg/domain/email/GetEmailAuthenticateStatusUseCase.kt
+++ b/core/domain/src/main/java/com/msg/domain/email/GetEmailAuthenticateStatusUseCase.kt
@@ -1,0 +1,12 @@
+package com.msg.domain.email
+
+import com.msg.data.repository.email.EmailRepository
+import javax.inject.Inject
+
+class GetEmailAuthenticateStatusUseCase @Inject constructor(
+    private val emailRepository: EmailRepository
+) {
+    suspend operator fun invoke(email: String) = runCatching {
+        emailRepository.getEmailAuthenticateStatus(email = email)
+    }
+}

--- a/core/domain/src/main/java/com/msg/domain/email/SendLinkToEmailUseCase.kt
+++ b/core/domain/src/main/java/com/msg/domain/email/SendLinkToEmailUseCase.kt
@@ -1,0 +1,13 @@
+package com.msg.domain.email
+
+import com.msg.data.repository.email.EmailRepository
+import com.msg.model.remote.request.email.SendLinkToEmailRequest
+import javax.inject.Inject
+
+class SendLinkToEmailUseCase @Inject constructor(
+    private val emailRepository: EmailRepository
+) {
+    suspend operator fun invoke(body: SendLinkToEmailRequest) = runCatching {
+        emailRepository.sendLinkToEmail(body = body)
+    }
+}

--- a/core/model/src/main/java/com/msg/model/remote/request/email/SendLinkToEmailRequest.kt
+++ b/core/model/src/main/java/com/msg/model/remote/request/email/SendLinkToEmailRequest.kt
@@ -1,0 +1,5 @@
+package com.msg.model.remote.request.email
+
+data class SendLinkToEmailRequest(
+    val email: String,
+)

--- a/core/model/src/main/java/com/msg/model/remote/response/email/GetEmailAuthenticateStatusResponse.kt
+++ b/core/model/src/main/java/com/msg/model/remote/response/email/GetEmailAuthenticateStatusResponse.kt
@@ -1,0 +1,5 @@
+package com.msg.model.remote.response.email
+
+data class GetEmailAuthenticateStatusResponse(
+    val isAuthentication: Boolean,
+)

--- a/core/network/src/main/java/com/msg/network/api/EmailAPI.kt
+++ b/core/network/src/main/java/com/msg/network/api/EmailAPI.kt
@@ -1,0 +1,20 @@
+package com.msg.network.api
+
+import com.msg.model.remote.request.email.SendLinkToEmailRequest
+import com.msg.model.remote.response.email.GetEmailAuthenticateStatusResponse
+import retrofit2.http.Body
+import retrofit2.http.GET
+import retrofit2.http.POST
+import retrofit2.http.Query
+
+interface EmailAPI {
+    @POST("email")
+    suspend fun sendLinkToEmail(
+        @Body body: SendLinkToEmailRequest
+    )
+
+    @GET("email")
+    suspend fun getEmailAuthenticateStatus(
+        @Query("email") email: String
+    ): GetEmailAuthenticateStatusResponse
+}

--- a/core/network/src/main/java/com/msg/network/datasource/email/EmailDataSource.kt
+++ b/core/network/src/main/java/com/msg/network/datasource/email/EmailDataSource.kt
@@ -1,0 +1,10 @@
+package com.msg.network.datasource.email
+
+import com.msg.model.remote.request.email.SendLinkToEmailRequest
+import com.msg.model.remote.response.email.GetEmailAuthenticateStatusResponse
+import kotlinx.coroutines.flow.Flow
+
+interface EmailDataSource {
+    suspend fun sendLinkToEmail(body: SendLinkToEmailRequest): Flow<Unit>
+    suspend fun getEmailAuthenticateStatus(email: String): Flow<GetEmailAuthenticateStatusResponse>
+}

--- a/core/network/src/main/java/com/msg/network/datasource/email/EmailDataSourceImpl.kt
+++ b/core/network/src/main/java/com/msg/network/datasource/email/EmailDataSourceImpl.kt
@@ -1,0 +1,31 @@
+package com.msg.network.datasource.email
+
+import com.msg.model.remote.request.email.SendLinkToEmailRequest
+import com.msg.model.remote.response.email.GetEmailAuthenticateStatusResponse
+import com.msg.network.api.EmailAPI
+import com.msg.network.util.BitgoeulApiHandler
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.flow
+import kotlinx.coroutines.flow.flowOn
+import javax.inject.Inject
+
+class EmailDataSourceImpl @Inject constructor(
+    private val emailAPI: EmailAPI
+) : EmailDataSource {
+    override suspend fun sendLinkToEmail(body: SendLinkToEmailRequest): Flow<Unit> = flow {
+        emit(
+            BitgoeulApiHandler<Unit>()
+                .httpRequest { emailAPI.sendLinkToEmail(body = body) }
+                .sendRequest()
+        )
+    }.flowOn(Dispatchers.IO)
+
+    override suspend fun getEmailAuthenticateStatus(email: String): Flow<GetEmailAuthenticateStatusResponse> = flow {
+        emit(
+            BitgoeulApiHandler<GetEmailAuthenticateStatusResponse>()
+                .httpRequest { emailAPI.getEmailAuthenticateStatus(email = email) }
+                .sendRequest()
+        )
+    }.flowOn(Dispatchers.IO)
+}

--- a/core/network/src/main/java/com/msg/network/di/DataSourceModule.kt
+++ b/core/network/src/main/java/com/msg/network/di/DataSourceModule.kt
@@ -10,6 +10,8 @@ import com.msg.network.datasource.certification.CertificationDataSource
 import com.msg.network.datasource.certification.CertificationDataSourceImpl
 import com.msg.network.datasource.club.ClubDataSource
 import com.msg.network.datasource.club.ClubDataSourceImpl
+import com.msg.network.datasource.email.EmailDataSource
+import com.msg.network.datasource.email.EmailDataSourceImpl
 import com.msg.network.datasource.faq.FaqDataSource
 import com.msg.network.datasource.faq.FaqDataSourceImpl
 import com.msg.network.datasource.lecture.LectureDataSource
@@ -70,4 +72,9 @@ abstract class DataSourceModule {
     abstract fun bindPostDataSource(
         postDataSourceImpl: PostDataSourceImpl
     ): PostDataSource
+
+    @Binds
+    abstract fun bindEmailDataSource(
+        emailDataSourceImpl: EmailDataSourceImpl
+    ): EmailDataSource
 }


### PR DESCRIPTION
## 💡 개요
새롭게 추가된 email Domain의 Network를 Setting
## 📃 작업내용
Email API 작성
EmailDataSource 작성
EmailRepository 작성
GetEmailAuthenticateStatusUseCase 작성
SendLinkToEmailUseCase 작성
## 🔀 변경사항
RepositoryModule에 EmailRepository 바인딩
DataSourceModule에 EmailDataSource 바인딩
## 🙋‍♂️ 질문사항
제가 잘못 세팅한 부분이 있거나 컨벤션에 맞지 않는 부분이 있다면 알려주세요.