### PR TITLE
🔀 :: (#163) Implementation Find Password

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -24,6 +24,7 @@ dependencies {
     implementation(project(":feature:my-page"))
     implementation(project(":feature:post"))
     implementation(project(":feature:club"))
+    implementation(project(":feature:email"))
 
     implementation(libs.junit)
     androidTestImplementation(libs.androidx.test.ext)

--- a/app/src/main/java/com/msg/bitgoeul_android/navigation/BitgoeulNavHost.kt
+++ b/app/src/main/java/com/msg/bitgoeul_android/navigation/BitgoeulNavHost.kt
@@ -3,6 +3,13 @@ package com.msg.bitgoeul_android.navigation
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Modifier
 import androidx.navigation.compose.NavHost
+import com.bitgoeul.email.navigation.emailSendInformScreen
+import com.bitgoeul.email.navigation.inputEmailScreen
+import com.bitgoeul.email.navigation.inputNewPasswordScreen
+import com.bitgoeul.email.navigation.navigateToEmailSendInform
+import com.bitgoeul.email.navigation.navigateToInputEmail
+import com.bitgoeul.email.navigation.navigateToInputNewPassword
+import com.bitgoeul.email.navigation.navigateToPasswordChangeSuccess
 import com.bitgoeul.login.navigation.loginRoute
 import com.bitgoeul.login.navigation.loginScreen
 import com.bitgoeul.login.navigation.navigateToLogin
@@ -18,7 +25,6 @@ import com.msg.lecture.navigation.lectureDetailScreen
 import com.msg.lecture.navigation.lectureDetailSettingScreen
 import com.msg.lecture.navigation.lectureListScreen
 import com.msg.lecture.navigation.lectureOpenScreen
-import com.msg.lecture.navigation.navigateToLecture
 import com.msg.lecture.navigation.navigateToLectureDetail
 import com.msg.lecture.navigation.navigateToLectureDetailSetting
 import com.msg.lecture.navigation.navigateToLectureOpen
@@ -52,7 +58,20 @@ fun BitgoeulNavHost(
         modifier = modifier
     ) {
         loginScreen(
-            onSignUpClick = navController::navigateToSignUp
+            onSignUpClick = navController::navigateToSignUp,
+            onFindPasswordClick = navController::navigateToInputEmail
+        )
+        inputEmailScreen(
+            onBackClicked = navController::navigateToLogin,
+            onNextClicked = navController::navigateToEmailSendInform
+        )
+        emailSendInformScreen(
+            onBackClicked = navController::navigateToInputEmail,
+            onMoveNewPasswordClick = navController::navigateToInputNewPassword
+        )
+        inputNewPasswordScreen(
+            onBackClicked = navController::navigateToInputEmail,
+            onNextClicked = navController::navigateToPasswordChangeSuccess
         )
         signUpScreen(
             onBackClick = navController::popBackStack

--- a/app/src/main/java/com/msg/bitgoeul_android/navigation/BitgoeulNavHost.kt
+++ b/app/src/main/java/com/msg/bitgoeul_android/navigation/BitgoeulNavHost.kt
@@ -10,6 +10,7 @@ import com.bitgoeul.email.navigation.navigateToEmailSendInform
 import com.bitgoeul.email.navigation.navigateToInputEmail
 import com.bitgoeul.email.navigation.navigateToInputNewPassword
 import com.bitgoeul.email.navigation.navigateToPasswordChangeSuccess
+import com.bitgoeul.email.navigation.passwordChangeSuccessScreen
 import com.bitgoeul.login.navigation.loginRoute
 import com.bitgoeul.login.navigation.loginScreen
 import com.bitgoeul.login.navigation.navigateToLogin
@@ -72,6 +73,9 @@ fun BitgoeulNavHost(
         inputNewPasswordScreen(
             onBackClicked = navController::navigateToInputEmail,
             onNextClicked = navController::navigateToPasswordChangeSuccess
+        )
+        passwordChangeSuccessScreen(
+            onBackClicked = navController::navigateToLogin
         )
         signUpScreen(
             onBackClick = navController::popBackStack

--- a/core/network/src/main/java/com/msg/network/di/NetworkModule.kt
+++ b/core/network/src/main/java/com/msg/network/di/NetworkModule.kt
@@ -7,6 +7,7 @@ import com.msg.network.api.AdminAPI
 import com.msg.network.api.AuthAPI
 import com.msg.network.api.CertificationAPI
 import com.msg.network.api.ClubAPI
+import com.msg.network.api.EmailAPI
 import com.msg.network.api.FaqAPI
 import com.msg.network.api.LectureAPI
 import com.msg.network.api.PostAPI
@@ -20,6 +21,7 @@ import okhttp3.OkHttpClient
 import okhttp3.logging.HttpLoggingInterceptor
 import retrofit2.Retrofit
 import retrofit2.converter.gson.GsonConverterFactory
+import retrofit2.create
 import java.util.concurrent.TimeUnit
 import javax.inject.Singleton
 
@@ -98,4 +100,8 @@ object NetworkModule {
     @Provides
     fun providePostAPI(retrofit: Retrofit): PostAPI =
         retrofit.create(PostAPI::class.java)
+
+    @Provides
+    fun provideEmailAPI(retrofit: Retrofit): EmailAPI =
+        retrofit.create(EmailAPI::class.java)
  }

--- a/feature/email/src/main/java/com/bitgoeul/email/EmailSendInformScreen.kt
+++ b/feature/email/src/main/java/com/bitgoeul/email/EmailSendInformScreen.kt
@@ -1,5 +1,7 @@
 package com.bitgoeul.email
 
+import android.widget.Toast
+import androidx.activity.ComponentActivity
 import androidx.compose.foundation.background
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Spacer
@@ -9,18 +11,65 @@ import androidx.compose.foundation.layout.padding
 import androidx.compose.material3.Surface
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.unit.dp
+import androidx.hilt.navigation.compose.hiltViewModel
+import com.bitgoeul.email.util.Event
+import com.bitgoeul.email.viewmodel.EmailViewModel
 import com.msg.design_system.component.icon.GoBackIcon
 import com.msg.design_system.component.topbar.GoBackTopBar
 import com.msg.design_system.theme.BitgoeulAndroidTheme
 import com.msg.design_system.R
+import com.msg.model.remote.response.email.GetEmailAuthenticateStatusResponse
+
+@Composable
+fun EmailSendInformRoute(
+    onBackClicked: () -> Unit,
+    onMoveNewPasswordClick: () -> Unit,
+    viewModel: EmailViewModel = hiltViewModel(LocalContext.current as ComponentActivity)
+) {
+    val context = LocalContext.current
+    LaunchedEffect(true) {
+        viewModel.getEmailAuthenticateStatus()
+        getEmailAuthenticateStatus(
+            viewModel = viewModel,
+            onSuccess = { response ->
+                if (response.isAuthentication) {
+                    onMoveNewPasswordClick()
+                } else {
+                    Toast.makeText(context, "이메일 인증에 실패했습니다.", Toast.LENGTH_SHORT).show()
+                }
+            }
+        )
+    }
+    EmailSendInformScreen(
+        onBackClicked = onBackClicked
+    )
+}
+
+suspend fun getEmailAuthenticateStatus(
+    viewModel: EmailViewModel,
+    onSuccess: (data: GetEmailAuthenticateStatusResponse) -> Unit,
+) {
+    viewModel.getEmailAuthenticateStatusResponse.collect { response ->
+        when (response) {
+            is Event.Success -> {
+                onSuccess(response.data!!)
+            }
+
+            else -> {}
+        }
+    }
+}
 
 @Composable
 fun EmailSendInformScreen(
-    modifier: Modifier = Modifier
+    modifier: Modifier = Modifier,
+    onBackClicked: () -> Unit
 ) {
     BitgoeulAndroidTheme { color, typography ->
         Surface {
@@ -36,7 +85,7 @@ fun EmailSendInformScreen(
                     icon = { GoBackIcon() },
                     text = stringResource(id = R.string.go_back)
                 ) {
-                    // TODO onBackClicked() 추가하기
+                    onBackClicked()
                 }
 
                 Spacer(modifier = modifier.weight(1f))

--- a/feature/email/src/main/java/com/bitgoeul/email/EmailSendInformScreen.kt
+++ b/feature/email/src/main/java/com/bitgoeul/email/EmailSendInformScreen.kt
@@ -1,7 +1,5 @@
 package com.bitgoeul.email
 
-import android.app.Activity
-import android.app.Application
 import android.util.Log
 import android.widget.Toast
 import androidx.activity.ComponentActivity
@@ -15,7 +13,6 @@ import androidx.compose.material3.Surface
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.DisposableEffect
-import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.rememberCoroutineScope
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
@@ -24,8 +21,6 @@ import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.unit.dp
 import androidx.hilt.navigation.compose.hiltViewModel
 import androidx.lifecycle.DefaultLifecycleObserver
-import androidx.lifecycle.Lifecycle
-import androidx.lifecycle.LifecycleObserver
 import androidx.lifecycle.LifecycleOwner
 import com.bitgoeul.email.util.Event
 import com.bitgoeul.email.viewmodel.EmailViewModel

--- a/feature/email/src/main/java/com/bitgoeul/email/InputEmailScreen.kt
+++ b/feature/email/src/main/java/com/bitgoeul/email/InputEmailScreen.kt
@@ -105,7 +105,7 @@ fun InputEmailScreen(
                         .padding(bottom = 14.dp)
                         .fillMaxWidth()
                         .height(52.dp),
-                    state = ButtonState.Disable,
+                    state = if(email.value.isNotEmpty()) ButtonState.Enable else ButtonState.Disable,
                     onClick = {
                         onNextClicked(email.value)
                     }

--- a/feature/email/src/main/java/com/bitgoeul/email/InputEmailScreen.kt
+++ b/feature/email/src/main/java/com/bitgoeul/email/InputEmailScreen.kt
@@ -1,5 +1,6 @@
 package com.bitgoeul.email
 
+import androidx.activity.ComponentActivity
 import androidx.compose.foundation.background
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Spacer
@@ -10,9 +11,14 @@ import androidx.compose.foundation.layout.padding
 import androidx.compose.material3.Surface
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.unit.dp
+import androidx.hilt.navigation.compose.hiltViewModel
+import com.bitgoeul.email.viewmodel.EmailViewModel
 import com.msg.design_system.component.icon.GoBackIcon
 import com.msg.design_system.component.topbar.GoBackTopBar
 import com.msg.design_system.theme.BitgoeulAndroidTheme
@@ -20,11 +26,26 @@ import com.msg.design_system.R
 import com.msg.design_system.component.button.BitgoeulButton
 import com.msg.design_system.component.button.ButtonState
 import com.msg.design_system.component.textfield.DefaultTextField
-
+@Composable
+fun InputEmailRoute(
+    onBackClicked: () -> Unit,
+    viewModel: EmailViewModel = hiltViewModel(LocalContext.current as ComponentActivity)
+) {
+    InputEmailScreen(
+        onBackClicked = onBackClicked,
+        onNextClicked = { email ->
+            viewModel.sendLinkToEmail(email)
+        }
+    )
+}
 @Composable
 fun InputEmailScreen(
-    modifier: Modifier = Modifier
+    modifier: Modifier = Modifier,
+    onBackClicked: () -> Unit,
+    onNextClicked: (String) -> Unit,
 ) {
+    val email = remember { mutableStateOf("") }
+
     BitgoeulAndroidTheme { color, typography ->
         Surface {
             Column(
@@ -39,7 +60,7 @@ fun InputEmailScreen(
                     icon = { GoBackIcon() },
                     text = stringResource(id = R.string.go_back)
                 ) {
-                    // TODO onBackClicked() 추가하기
+                    onBackClicked()
                 }
 
                 Spacer(modifier = modifier.height(16.dp))
@@ -60,7 +81,9 @@ fun InputEmailScreen(
 
                 DefaultTextField(
                     modifier = modifier.fillMaxWidth(),
-                    onValueChange = { },
+                    onValueChange = { inputEmail ->
+                        email.value = inputEmail
+                    },
                     errorText = "",
                     isDisabled = false,
                     isError = false,
@@ -79,7 +102,9 @@ fun InputEmailScreen(
                         .fillMaxWidth()
                         .height(52.dp),
                     state = ButtonState.Disable,
-                    onClick = {}
+                    onClick = {
+                        onNextClicked(email.value)
+                    }
                 )
             }
         }

--- a/feature/email/src/main/java/com/bitgoeul/email/InputEmailScreen.kt
+++ b/feature/email/src/main/java/com/bitgoeul/email/InputEmailScreen.kt
@@ -26,15 +26,18 @@ import com.msg.design_system.R
 import com.msg.design_system.component.button.BitgoeulButton
 import com.msg.design_system.component.button.ButtonState
 import com.msg.design_system.component.textfield.DefaultTextField
+
 @Composable
 fun InputEmailRoute(
     onBackClicked: () -> Unit,
+    onNextClicked: () -> Unit,
     viewModel: EmailViewModel = hiltViewModel(LocalContext.current as ComponentActivity)
 ) {
     InputEmailScreen(
         onBackClicked = onBackClicked,
         onNextClicked = { email ->
             viewModel.sendLinkToEmail(email)
+            onNextClicked()
         }
     )
 }

--- a/feature/email/src/main/java/com/bitgoeul/email/InputEmailScreen.kt
+++ b/feature/email/src/main/java/com/bitgoeul/email/InputEmailScreen.kt
@@ -36,7 +36,8 @@ fun InputEmailRoute(
     InputEmailScreen(
         onBackClicked = onBackClicked,
         onNextClicked = { email ->
-            viewModel.sendLinkToEmail(email)
+            viewModel.email.value = email
+            viewModel.sendLinkToEmail()
             onNextClicked()
         }
     )

--- a/feature/email/src/main/java/com/bitgoeul/email/InputNewPasswordScreen.kt
+++ b/feature/email/src/main/java/com/bitgoeul/email/InputNewPasswordScreen.kt
@@ -36,7 +36,10 @@ fun InputNewPasswordRoute(
     InputNewPasswordScreen(
         onBackClicked = onBackClicked,
         onNextClicked = { currentPassword, newPassword ->
-
+            viewModel.currentPassword.value = currentPassword
+            viewModel.newPassword.value = newPassword
+            viewModel.changePassword()
+            onNextClicked()
         },
     )
 }
@@ -64,7 +67,7 @@ fun InputNewPasswordScreen(
                     icon = { GoBackIcon() },
                     text = stringResource(id = R.string.go_back)
                 ) {
-                    // TODO onBackClicked() 추가하기
+                    onBackClicked()
                 }
 
                 Spacer(modifier = modifier.height(16.dp))

--- a/feature/email/src/main/java/com/bitgoeul/email/InputNewPasswordScreen.kt
+++ b/feature/email/src/main/java/com/bitgoeul/email/InputNewPasswordScreen.kt
@@ -127,7 +127,7 @@ fun InputNewPasswordScreen(
                         .padding(bottom = 14.dp)
                         .fillMaxWidth()
                         .height(52.dp),
-                    state = ButtonState.Disable,
+                    state = if(currentPassword.value.isNotEmpty() && newPassword.value.isNotEmpty()) ButtonState.Enable else ButtonState.Disable,
                     onClick = {
                         onNextClicked(currentPassword.value, newPassword.value)
                     }

--- a/feature/email/src/main/java/com/bitgoeul/email/InputNewPasswordScreen.kt
+++ b/feature/email/src/main/java/com/bitgoeul/email/InputNewPasswordScreen.kt
@@ -1,5 +1,6 @@
 package com.bitgoeul.email
 
+import android.widget.Toast
 import androidx.activity.ComponentActivity
 import androidx.compose.foundation.background
 import androidx.compose.foundation.layout.Column
@@ -35,10 +36,9 @@ fun InputNewPasswordRoute(
 ) {
     InputNewPasswordScreen(
         onBackClicked = onBackClicked,
-        onNextClicked = { currentPassword, newPassword ->
-            viewModel.currentPassword.value = currentPassword
+        onNextClicked = { newPassword ->
             viewModel.newPassword.value = newPassword
-            viewModel.changePassword()
+            viewModel.findPassword()
             onNextClicked()
         },
     )
@@ -48,10 +48,12 @@ fun InputNewPasswordRoute(
 fun InputNewPasswordScreen(
     modifier: Modifier = Modifier,
     onBackClicked: () -> Unit,
-    onNextClicked: (String, String) -> Unit,
+    onNextClicked: (String) -> Unit,
 ) {
-    val currentPassword = remember { mutableStateOf("") }
-    val newPassword = remember { mutableStateOf("") }
+    val passwordPattern = Regex("^(?=.*[A-Za-z0-9])[A-Za-z0-9!@#$%^&*]{8,24}$")
+    val firstInputPassword = remember { mutableStateOf("") }
+    val secondInputPassword = remember { mutableStateOf("") }
+    val context = LocalContext.current
 
     BitgoeulAndroidTheme { color, typography ->
         Surface {
@@ -89,8 +91,8 @@ fun InputNewPasswordScreen(
 
                 DefaultTextField(
                     modifier = modifier.fillMaxWidth(),
-                    onValueChange = { inputCurrentPassword ->
-                        currentPassword.value = inputCurrentPassword
+                    onValueChange = { inputPassword ->
+                        firstInputPassword.value = inputPassword
                     },
                     errorText = "",
                     isDisabled = false,
@@ -106,12 +108,12 @@ fun InputNewPasswordScreen(
 
                 DefaultTextField(
                     modifier = modifier.fillMaxWidth(),
-                    onValueChange = { inputNewPassword ->
-                        newPassword.value = inputNewPassword
+                    onValueChange = { inputPassword ->
+                        secondInputPassword.value = inputPassword
                     },
-                    errorText = "",
+                    errorText = "비밀번호가 일치하지 않습니다.",
                     isDisabled = false,
-                    isError = false,
+                    isError = firstInputPassword.value != secondInputPassword.value,
                     isLinked = false,
                     isReverseTrailingIcon = false,
                     onClickButton = {},
@@ -127,9 +129,13 @@ fun InputNewPasswordScreen(
                         .padding(bottom = 14.dp)
                         .fillMaxWidth()
                         .height(52.dp),
-                    state = if(currentPassword.value.isNotEmpty() && newPassword.value.isNotEmpty()) ButtonState.Enable else ButtonState.Disable,
+                    state = if(firstInputPassword.value.isNotEmpty() && secondInputPassword.value.isNotEmpty()) ButtonState.Enable else ButtonState.Disable,
                     onClick = {
-                        onNextClicked(currentPassword.value, newPassword.value)
+                        if (passwordPattern.matches(firstInputPassword.value)) {
+                            onNextClicked(secondInputPassword.value)
+                        } else {
+                            Toast.makeText(context, "비밀번호는 8~24자 영문, 숫자, 특수문자 1개 이상이어야 합니다.", Toast.LENGTH_SHORT).show()
+                        }
                     }
                 )
             }

--- a/feature/email/src/main/java/com/bitgoeul/email/InputNewPasswordScreen.kt
+++ b/feature/email/src/main/java/com/bitgoeul/email/InputNewPasswordScreen.kt
@@ -22,6 +22,15 @@ import com.msg.design_system.component.topbar.GoBackTopBar
 import com.msg.design_system.theme.BitgoeulAndroidTheme
 
 @Composable
+fun InputNewPasswordRoute(
+    onBackClicked: () -> Unit,
+    onNextClicked: () -> Unit,
+) {
+    InputNewPasswordScreen(
+    )
+}
+
+@Composable
 fun InputNewPasswordScreen(
     modifier: Modifier = Modifier
 ) {

--- a/feature/email/src/main/java/com/bitgoeul/email/InputNewPasswordScreen.kt
+++ b/feature/email/src/main/java/com/bitgoeul/email/InputNewPasswordScreen.kt
@@ -1,5 +1,6 @@
 package com.bitgoeul.email
 
+import androidx.activity.ComponentActivity
 import androidx.compose.foundation.background
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Spacer
@@ -10,9 +11,14 @@ import androidx.compose.foundation.layout.padding
 import androidx.compose.material3.Surface
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.unit.dp
+import androidx.hilt.navigation.compose.hiltViewModel
+import com.bitgoeul.email.viewmodel.EmailViewModel
 import com.msg.design_system.R
 import com.msg.design_system.component.button.BitgoeulButton
 import com.msg.design_system.component.button.ButtonState
@@ -25,15 +31,25 @@ import com.msg.design_system.theme.BitgoeulAndroidTheme
 fun InputNewPasswordRoute(
     onBackClicked: () -> Unit,
     onNextClicked: () -> Unit,
+    viewModel: EmailViewModel = hiltViewModel(LocalContext.current as ComponentActivity)
 ) {
     InputNewPasswordScreen(
+        onBackClicked = onBackClicked,
+        onNextClicked = { currentPassword, newPassword ->
+
+        },
     )
 }
 
 @Composable
 fun InputNewPasswordScreen(
-    modifier: Modifier = Modifier
+    modifier: Modifier = Modifier,
+    onBackClicked: () -> Unit,
+    onNextClicked: (String, String) -> Unit,
 ) {
+    val currentPassword = remember { mutableStateOf("") }
+    val newPassword = remember { mutableStateOf("") }
+
     BitgoeulAndroidTheme { color, typography ->
         Surface {
             Column(
@@ -70,7 +86,9 @@ fun InputNewPasswordScreen(
 
                 DefaultTextField(
                     modifier = modifier.fillMaxWidth(),
-                    onValueChange = { },
+                    onValueChange = { inputCurrentPassword ->
+                        currentPassword.value = inputCurrentPassword
+                    },
                     errorText = "",
                     isDisabled = false,
                     isError = false,
@@ -85,7 +103,9 @@ fun InputNewPasswordScreen(
 
                 DefaultTextField(
                     modifier = modifier.fillMaxWidth(),
-                    onValueChange = { },
+                    onValueChange = { inputNewPassword ->
+                        newPassword.value = inputNewPassword
+                    },
                     errorText = "",
                     isDisabled = false,
                     isError = false,
@@ -105,7 +125,9 @@ fun InputNewPasswordScreen(
                         .fillMaxWidth()
                         .height(52.dp),
                     state = ButtonState.Disable,
-                    onClick = {}
+                    onClick = {
+                        onNextClicked(currentPassword.value, newPassword.value)
+                    }
                 )
             }
         }

--- a/feature/email/src/main/java/com/bitgoeul/email/PasswordChangeSuccessScreen.kt
+++ b/feature/email/src/main/java/com/bitgoeul/email/PasswordChangeSuccessScreen.kt
@@ -20,8 +20,17 @@ import com.msg.design_system.component.button.ButtonState
 import com.msg.design_system.theme.BitgoeulAndroidTheme
 
 @Composable
+fun PasswordChangeSuccessRoute(
+    onBackClicked: () -> Unit
+) {
+    PasswordChangeSuccessScreen(
+        onBackClicked = onBackClicked
+    )
+}
+@Composable
 fun PasswordChangeSuccessScreen(
-    modifier: Modifier = Modifier
+    modifier: Modifier = Modifier,
+    onBackClicked: () -> Unit
 ) {
     BitgoeulAndroidTheme { color, typography ->
         Surface {
@@ -65,7 +74,9 @@ fun PasswordChangeSuccessScreen(
                         .fillMaxWidth()
                         .height(52.dp),
                     state = ButtonState.Enable,
-                    onClick = {}
+                    onClick = {
+                        onBackClicked()
+                    }
                 )
             }
         }

--- a/feature/email/src/main/java/com/bitgoeul/email/navigation/EmailNavigation.kt
+++ b/feature/email/src/main/java/com/bitgoeul/email/navigation/EmailNavigation.kt
@@ -1,10 +1,25 @@
 package com.bitgoeul.email.navigation
 
 import androidx.navigation.NavController
+import androidx.navigation.NavGraphBuilder
 import androidx.navigation.NavOptions
+import androidx.navigation.compose.composable
+import com.bitgoeul.email.InputEmailRoute
 
 const val inputEmailRoute = "input_email_route"
 
 fun NavController.navigateToInputEmail(navOptions: NavOptions? = null) {
     this.navigate(inputEmailRoute, navOptions)
+}
+
+fun NavGraphBuilder.inputEmailScreen(
+    onBackClicked: () -> Unit,
+    onNextClicked: () -> Unit,
+) {
+    composable(route = inputEmailRoute) {
+        InputEmailRoute(
+            onBackClicked = onBackClicked,
+            onNextClicked = onNextClicked,
+        )
+    }
 }

--- a/feature/email/src/main/java/com/bitgoeul/email/navigation/EmailNavigation.kt
+++ b/feature/email/src/main/java/com/bitgoeul/email/navigation/EmailNavigation.kt
@@ -1,0 +1,10 @@
+package com.bitgoeul.email.navigation
+
+import androidx.navigation.NavController
+import androidx.navigation.NavOptions
+
+const val inputEmailRoute = "input_email_route"
+
+fun NavController.navigateToInputEmail(navOptions: NavOptions? = null) {
+    this.navigate(inputEmailRoute, navOptions)
+}

--- a/feature/email/src/main/java/com/bitgoeul/email/navigation/EmailNavigation.kt
+++ b/feature/email/src/main/java/com/bitgoeul/email/navigation/EmailNavigation.kt
@@ -4,12 +4,19 @@ import androidx.navigation.NavController
 import androidx.navigation.NavGraphBuilder
 import androidx.navigation.NavOptions
 import androidx.navigation.compose.composable
+import com.bitgoeul.email.EmailSendInformRoute
 import com.bitgoeul.email.InputEmailRoute
 
 const val inputEmailRoute = "input_email_route"
 
+const val emailSendInformRoute = "email_send_inform_route"
+
 fun NavController.navigateToInputEmail(navOptions: NavOptions? = null) {
     this.navigate(inputEmailRoute, navOptions)
+}
+
+fun NavController.navigateToEmailSendInform(navOptions: NavOptions? = null) {
+    this.navigate(emailSendInformRoute, navOptions)
 }
 
 fun NavGraphBuilder.inputEmailScreen(
@@ -20,6 +27,18 @@ fun NavGraphBuilder.inputEmailScreen(
         InputEmailRoute(
             onBackClicked = onBackClicked,
             onNextClicked = onNextClicked,
+        )
+    }
+}
+
+fun NavGraphBuilder.emailSendInformScreen(
+    onBackClicked: () -> Unit,
+    onMoveNewPasswordClick: () -> Unit,
+) {
+    composable(route = emailSendInformRoute) {
+        EmailSendInformRoute(
+            onBackClicked = onBackClicked,
+            onMoveNewPasswordClick = onMoveNewPasswordClick,
         )
     }
 }

--- a/feature/email/src/main/java/com/bitgoeul/email/navigation/EmailNavigation.kt
+++ b/feature/email/src/main/java/com/bitgoeul/email/navigation/EmailNavigation.kt
@@ -7,12 +7,15 @@ import androidx.navigation.compose.composable
 import com.bitgoeul.email.EmailSendInformRoute
 import com.bitgoeul.email.InputEmailRoute
 import com.bitgoeul.email.InputNewPasswordRoute
+import com.bitgoeul.email.PasswordChangeSuccessRoute
 
 const val inputEmailRoute = "input_email_route"
 
 const val emailSendInformRoute = "email_send_inform_route"
 
 const val inputNewPasswordRoute = "input_new_password_route"
+
+const val passwordChangeSuccessRoute = "password_change_success_route"
 
 fun NavController.navigateToInputEmail(navOptions: NavOptions? = null) {
     this.navigate(inputEmailRoute, navOptions)
@@ -24,6 +27,10 @@ fun NavController.navigateToEmailSendInform(navOptions: NavOptions? = null) {
 
 fun NavController.navigateToInputNewPassword(navOptions: NavOptions? = null) {
     this.navigate(inputNewPasswordRoute, navOptions)
+}
+
+fun NavController.navigateToPasswordChangeSuccess(navOptions: NavOptions? = null) {
+    this.navigate(passwordChangeSuccessRoute, navOptions)
 }
 
 fun NavGraphBuilder.inputEmailScreen(
@@ -58,6 +65,16 @@ fun NavGraphBuilder.inputNewPasswordScreen(
         InputNewPasswordRoute(
             onBackClicked = onBackClicked,
             onNextClicked = onNextClicked
+        )
+    }
+}
+
+fun NavGraphBuilder.passwordChangeSuccessScreen(
+    onBackClicked: () -> Unit
+) {
+    composable(route = passwordChangeSuccessRoute) {
+        PasswordChangeSuccessRoute(
+            onBackClicked = onBackClicked
         )
     }
 }

--- a/feature/email/src/main/java/com/bitgoeul/email/navigation/EmailNavigation.kt
+++ b/feature/email/src/main/java/com/bitgoeul/email/navigation/EmailNavigation.kt
@@ -6,10 +6,13 @@ import androidx.navigation.NavOptions
 import androidx.navigation.compose.composable
 import com.bitgoeul.email.EmailSendInformRoute
 import com.bitgoeul.email.InputEmailRoute
+import com.bitgoeul.email.InputNewPasswordRoute
 
 const val inputEmailRoute = "input_email_route"
 
 const val emailSendInformRoute = "email_send_inform_route"
+
+const val inputNewPasswordRoute = "input_new_password_route"
 
 fun NavController.navigateToInputEmail(navOptions: NavOptions? = null) {
     this.navigate(inputEmailRoute, navOptions)
@@ -17,6 +20,10 @@ fun NavController.navigateToInputEmail(navOptions: NavOptions? = null) {
 
 fun NavController.navigateToEmailSendInform(navOptions: NavOptions? = null) {
     this.navigate(emailSendInformRoute, navOptions)
+}
+
+fun NavController.navigateToInputNewPassword(navOptions: NavOptions? = null) {
+    this.navigate(inputNewPasswordRoute, navOptions)
 }
 
 fun NavGraphBuilder.inputEmailScreen(
@@ -39,6 +46,18 @@ fun NavGraphBuilder.emailSendInformScreen(
         EmailSendInformRoute(
             onBackClicked = onBackClicked,
             onMoveNewPasswordClick = onMoveNewPasswordClick,
+        )
+    }
+}
+
+fun NavGraphBuilder.inputNewPasswordScreen(
+    onBackClicked: () -> Unit,
+    onNextClicked: () -> Unit
+) {
+    composable(route = inputNewPasswordRoute) {
+        InputNewPasswordRoute(
+            onBackClicked = onBackClicked,
+            onNextClicked = onNextClicked
         )
     }
 }

--- a/feature/email/src/main/java/com/bitgoeul/email/util/Event.kt
+++ b/feature/email/src/main/java/com/bitgoeul/email/util/Event.kt
@@ -1,0 +1,59 @@
+package com.bitgoeul.email.util
+
+sealed class Event<out T>(
+    val data: T? = null,
+) {
+
+    object Loading : Event<Nothing>()
+
+    /**
+     * 성공
+     */
+    class Success<T>(data: T? = null) : Event<T>(data = data)
+
+    /**
+     * 400번 요청이 올바르지 않은 경우
+     */
+    object BadRequest : Event<Nothing>()
+
+    /**
+     * 401번 비인증 요청
+     */
+    object Unauthorized : Event<Nothing>()
+
+    /**
+     * 403번 권한이 없음
+     */
+    object ForBidden : Event<Nothing>()
+
+    /**
+     * 404 찾을 수 없는 경우
+     */
+    object NotFound : Event<Nothing>()
+
+    /**
+     * 406 맞는 규격이 없는 경우
+     */
+    object NotAcceptable : Event<Nothing>()
+
+    /**
+     * 408 요청이 너무 오래 걸리는 경우
+     */
+    object TimeOut : Event<Nothing>()
+
+    /**
+     * 409 권한이 없을 때
+     */
+    object Conflict : Event<Nothing>()
+
+    /**
+     * 50X 서버에러
+     */
+    object Server : Event<Nothing>()
+
+    /**
+     * 예상치 못한 에러
+     */
+    object UnKnown : Event<Nothing>()
+
+}

--- a/feature/email/src/main/java/com/bitgoeul/email/util/errorHandling.kt
+++ b/feature/email/src/main/java/com/bitgoeul/email/util/errorHandling.kt
@@ -1,0 +1,68 @@
+package com.bitgoeul.email.util
+
+import android.util.Log
+import com.msg.domain.exception.*
+
+//추후 리팩토링을 통해 다른 모듈? 패키지로 이동 예정
+suspend fun <T> Throwable.errorHandling(
+    badRequestAction: suspend () -> Unit = {},
+    unauthorizedAction: suspend () -> Unit = {},
+    forBiddenAction: suspend () -> Unit = {},
+    notFoundAction: suspend () -> Unit = {},
+    notAcceptableAction: suspend () -> Unit = {},
+    timeOutAction: suspend () -> Unit = {},
+    conflictAction: suspend () -> Unit = {},
+    serverAction: suspend () -> Unit = {},
+    unknownAction: suspend () -> Unit = {},
+): Event<T> =
+    when (this) {
+        is BadRequestException -> {
+            errorLog("BadRequestException", message)
+            badRequestAction()
+            Event.BadRequest
+        }
+        is UnauthorizedException, is NeedLoginException -> {
+            errorLog("UnauthorizedException", message)
+            unauthorizedAction()
+            Event.Unauthorized
+        }
+        is ForBiddenException -> {
+            errorLog("ForBiddenException", message)
+            forBiddenAction()
+            Event.ForBidden
+        }
+        is NotFoundException -> {
+            errorLog("NotFoundException", message)
+            notFoundAction()
+            Event.NotFound
+        }
+        is NotAcceptableException -> {
+            errorLog("NotAcceptableException", message)
+            notAcceptableAction()
+            Event.NotAcceptable
+        }
+        is TimeOutException -> {
+            errorLog("TimeOutException", message)
+            timeOutAction()
+            Event.TimeOut
+        }
+        is ConflictException -> {
+            errorLog("ConflictException", message)
+            conflictAction()
+            Event.Conflict
+        }
+        is ServerException -> {
+            errorLog("ServerException", message)
+            serverAction()
+            Event.Server
+        }
+        else -> {
+            errorLog("UnKnownException", message)
+            unknownAction()
+            Event.UnKnown
+        }
+    }
+
+private fun errorLog(tag: String, msg: String?) {
+    Log.d("ErrorHandling-$tag", msg ?: "알 수 없는 오류")
+}

--- a/feature/email/src/main/java/com/bitgoeul/email/viewmodel/EmailViewModel.kt
+++ b/feature/email/src/main/java/com/bitgoeul/email/viewmodel/EmailViewModel.kt
@@ -43,6 +43,9 @@ class EmailViewModel @Inject constructor(
     var newPassword = mutableStateOf("")
         private set
 
+    var authenticateStatus = mutableStateOf<Boolean?>(false)
+        private set
+
     fun getEmailAuthenticateStatus() = viewModelScope.launch {
        getEmailAuthenticateStatusUseCase(
            email = email.value
@@ -51,6 +54,7 @@ class EmailViewModel @Inject constructor(
                _getEmailAuthenticateStatusResponse.value = remoteError.errorHandling()
            }.collect { response ->
                _getEmailAuthenticateStatusResponse.value = Event.Success(data = response)
+               authenticateStatus.value = response.isAuthentication
            }
        }.onFailure { error ->
            _getEmailAuthenticateStatusResponse.value = error.errorHandling()

--- a/feature/email/src/main/java/com/bitgoeul/email/viewmodel/EmailViewModel.kt
+++ b/feature/email/src/main/java/com/bitgoeul/email/viewmodel/EmailViewModel.kt
@@ -7,6 +7,7 @@ import com.bitgoeul.email.util.Event
 import com.bitgoeul.email.util.errorHandling
 import com.msg.domain.email.GetEmailAuthenticateStatusUseCase
 import com.msg.domain.email.SendLinkToEmailUseCase
+import com.msg.model.remote.request.email.SendLinkToEmailRequest
 import com.msg.model.remote.response.email.GetEmailAuthenticateStatusResponse
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.asStateFlow
@@ -42,5 +43,23 @@ class EmailViewModel @Inject constructor(
        }.onFailure { error ->
            _getEmailAuthenticateStatusResponse.value = error.errorHandling()
        }
+    }
+
+    fun sendLinkToEmail(
+        email: String
+    ) = viewModelScope.launch {
+        sendLinkToEmailUseCase(
+            body = SendLinkToEmailRequest(
+                email = email
+            )
+        ).onSuccess {
+            it.catch {remoteError ->
+                _sendLinkToEmailResponse.value = remoteError.errorHandling()
+            }.collect {
+                _sendLinkToEmailResponse.value = Event.Success()
+            }
+        }.onFailure { error ->
+            _sendLinkToEmailResponse.value = error.errorHandling()
+        }
     }
 }

--- a/feature/email/src/main/java/com/bitgoeul/email/viewmodel/EmailViewModel.kt
+++ b/feature/email/src/main/java/com/bitgoeul/email/viewmodel/EmailViewModel.kt
@@ -1,0 +1,46 @@
+package com.bitgoeul.email.viewmodel
+
+import androidx.compose.runtime.mutableStateOf
+import androidx.lifecycle.ViewModel
+import androidx.lifecycle.viewModelScope
+import com.bitgoeul.email.util.Event
+import com.bitgoeul.email.util.errorHandling
+import com.msg.domain.email.GetEmailAuthenticateStatusUseCase
+import com.msg.domain.email.SendLinkToEmailUseCase
+import com.msg.model.remote.response.email.GetEmailAuthenticateStatusResponse
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.asStateFlow
+import kotlinx.coroutines.flow.catch
+import kotlinx.coroutines.launch
+import javax.inject.Inject
+
+class EmailViewModel @Inject constructor(
+    private val sendLinkToEmailUseCase: SendLinkToEmailUseCase,
+    private val getEmailAuthenticateStatusUseCase: GetEmailAuthenticateStatusUseCase,
+) : ViewModel() {
+
+    private val _sendLinkToEmailResponse = MutableStateFlow<Event<Unit>>(Event.Loading)
+    val sendLinkToEmailResponse = _sendLinkToEmailResponse.asStateFlow()
+
+    private val _getEmailAuthenticateStatusResponse = MutableStateFlow<Event<GetEmailAuthenticateStatusResponse>>(Event.Loading)
+    val getEmailAuthenticateStatusResponse = _getEmailAuthenticateStatusResponse.asStateFlow()
+
+    var email = mutableStateOf("")
+        private set
+
+    fun getEmailAuthenticateStatus(
+        email: String
+    ) = viewModelScope.launch {
+       getEmailAuthenticateStatusUseCase(
+           email = email
+       ).onSuccess {
+           it.catch {remoteError ->
+               _getEmailAuthenticateStatusResponse.value = remoteError.errorHandling()
+           }.collect { response ->
+               _getEmailAuthenticateStatusResponse.value = Event.Success(data = response)
+           }
+       }.onFailure { error ->
+           _getEmailAuthenticateStatusResponse.value = error.errorHandling()
+       }
+    }
+}

--- a/feature/email/src/main/java/com/bitgoeul/email/viewmodel/EmailViewModel.kt
+++ b/feature/email/src/main/java/com/bitgoeul/email/viewmodel/EmailViewModel.kt
@@ -29,11 +29,9 @@ class EmailViewModel @Inject constructor(
     var email = mutableStateOf("")
         private set
 
-    fun getEmailAuthenticateStatus(
-        email: String
-    ) = viewModelScope.launch {
+    fun getEmailAuthenticateStatus() = viewModelScope.launch {
        getEmailAuthenticateStatusUseCase(
-           email = email
+           email = email.value
        ).onSuccess {
            it.catch {remoteError ->
                _getEmailAuthenticateStatusResponse.value = remoteError.errorHandling()
@@ -45,12 +43,10 @@ class EmailViewModel @Inject constructor(
        }
     }
 
-    fun sendLinkToEmail(
-        email: String
-    ) = viewModelScope.launch {
+    fun sendLinkToEmail() = viewModelScope.launch {
         sendLinkToEmailUseCase(
             body = SendLinkToEmailRequest(
-                email = email
+                email = email.value
             )
         ).onSuccess {
             it.catch {remoteError ->

--- a/feature/email/src/main/java/com/bitgoeul/email/viewmodel/EmailViewModel.kt
+++ b/feature/email/src/main/java/com/bitgoeul/email/viewmodel/EmailViewModel.kt
@@ -11,12 +11,14 @@ import com.msg.domain.email.SendLinkToEmailUseCase
 import com.msg.model.remote.request.email.SendLinkToEmailRequest
 import com.msg.model.remote.request.user.ChangePasswordRequest
 import com.msg.model.remote.response.email.GetEmailAuthenticateStatusResponse
+import dagger.hilt.android.lifecycle.HiltViewModel
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.asStateFlow
 import kotlinx.coroutines.flow.catch
 import kotlinx.coroutines.launch
 import javax.inject.Inject
 
+@HiltViewModel
 class EmailViewModel @Inject constructor(
     private val sendLinkToEmailUseCase: SendLinkToEmailUseCase,
     private val getEmailAuthenticateStatusUseCase: GetEmailAuthenticateStatusUseCase,

--- a/feature/email/src/main/java/com/bitgoeul/email/viewmodel/EmailViewModel.kt
+++ b/feature/email/src/main/java/com/bitgoeul/email/viewmodel/EmailViewModel.kt
@@ -35,6 +35,12 @@ class EmailViewModel @Inject constructor(
     var email = mutableStateOf("")
         private set
 
+    var currentPassword = mutableStateOf("")
+        private set
+
+    var newPassword = mutableStateOf("")
+        private set
+
     fun getEmailAuthenticateStatus() = viewModelScope.launch {
        getEmailAuthenticateStatusUseCase(
            email = email.value
@@ -66,10 +72,12 @@ class EmailViewModel @Inject constructor(
     }
 
     fun changePassword(
-        body: ChangePasswordRequest
     ) = viewModelScope.launch {
         changePasswordUseCase(
-            body = body
+            body = ChangePasswordRequest(
+                currentPassword = currentPassword.value,
+                newPassword = newPassword.value
+            )
         ).onSuccess {
             it.catch {remoteError ->
                 _changePasswordResponse.value = remoteError.errorHandling()

--- a/feature/login/src/main/java/com/bitgoeul/login/LoginScreen.kt
+++ b/feature/login/src/main/java/com/bitgoeul/login/LoginScreen.kt
@@ -40,19 +40,21 @@ import com.msg.model.remote.request.auth.LoginRequest
 @Composable
 fun LoginRoute(
     onSignUpClick: () -> Unit,
+    onFindPasswordClick: () -> Unit,
     viewModel: AuthViewModel = hiltViewModel(),
 ) {
     val lifecycleOwner = LocalLifecycleOwner.current
 
     LoginScreen(
         onSignUpClick = onSignUpClick,
+        onFindPasswordClick = onFindPasswordClick,
         onLoginClick = {
             viewModel.login(LoginRequest(viewModel.email.value, viewModel.password.value))
             observeLoginEvent(lifecycleOwner = lifecycleOwner, viewModel = viewModel)
         },
         setLoginData = { email, password ->
             viewModel.setLoginData(email = email, password = password)
-        }
+        },
     )
 }
 
@@ -90,7 +92,7 @@ fun observeLoginEvent(
 fun LoginScreen(
     onSignUpClick: () -> Unit,
     onLoginClick: () -> Unit = {},
-    onFindPasswordClick: () -> Unit = {},
+    onFindPasswordClick: () -> Unit,
     setLoginData: (String, String) -> Unit = { _, _ -> },
 ) {
     LockScreenOrientation(orientation = ActivityInfo.SCREEN_ORIENTATION_PORTRAIT)
@@ -219,9 +221,4 @@ fun LoginScreen(
             }
         }
     }
-}
-
-@Composable
-fun preview() {
-    LoginScreen(onSignUpClick = {})
 }

--- a/feature/login/src/main/java/com/bitgoeul/login/LoginScreen.kt
+++ b/feature/login/src/main/java/com/bitgoeul/login/LoginScreen.kt
@@ -73,9 +73,11 @@ fun observeLoginEvent(
                     Log.e("토큰 저장 실패", "토큰이 유효하지 않습니다.")
                 }
             }
+
             is Event.UnKnown -> {
                 Log.e("Unknown Event", "Unknown 이벤트가 발생했습니다.")
             }
+
             else -> {
                 Log.e("토큰 저장 실패", "이벤트 타입이 올바르지 않습니다.")
             }
@@ -88,6 +90,7 @@ fun observeLoginEvent(
 fun LoginScreen(
     onSignUpClick: () -> Unit,
     onLoginClick: () -> Unit = {},
+    onFindPasswordClick: () -> Unit = {},
     setLoginData: (String, String) -> Unit = { _, _ -> },
 ) {
     LockScreenOrientation(orientation = ActivityInfo.SCREEN_ORIENTATION_PORTRAIT)
@@ -166,7 +169,9 @@ fun LoginScreen(
                         onValueChange = {
                             passwordState.value = it
                         },
-                        onClickLink = {},
+                        onClickLink = {
+                            onFindPasswordClick()
+                        },
                         isError = isPasswordErrorStatus.value,
                         isLinked = true,
                         linkText = stringResource(id = R.string.find_password),

--- a/feature/login/src/main/java/com/bitgoeul/login/navigation/LoginNavigation.kt
+++ b/feature/login/src/main/java/com/bitgoeul/login/navigation/LoginNavigation.kt
@@ -12,10 +12,14 @@ fun NavController.navigateToLogin(navOptions: NavOptions? = null) {
     this.navigate(loginRoute, navOptions)
 }
 
-fun NavGraphBuilder.loginScreen(onSignUpClick: () -> Unit) {
+fun NavGraphBuilder.loginScreen(
+    onSignUpClick: () -> Unit,
+    onFindPasswordClick: () -> Unit,
+) {
     composable(route = loginRoute) {
         LoginRoute(
-            onSignUpClick = onSignUpClick
+            onSignUpClick = onSignUpClick,
+            onFindPasswordClick = onFindPasswordClick
         )
     }
 }


### PR DESCRIPTION
## 💡 개요
비밀번호 찾기 기능 구현
## 📃 작업내용
email feature module의 Screen의 기능을 구현했습니다.
## 🔀 변경사항
- inputEmailScreen
- emailSendInformScreen
- inputNewPasswordScreen
- passwordChangeSuccessScreen
위의 Screen이 BitgoeulNavHost에 추가되었습니다.

LoginScreen의 PasswordTextField의 LinkText에 onFindPasswordClick 액션이 추가되었습니다.

## 🙋‍♂️ 질문사항
- 제가 잘못 작성한 부분이 있거나 불필요한 공백, 컨벤션에 맞지 않는 부분이 있다면 알려주세요.

- 현재 이메일 인증상태를 체크하는 화면에서 Resume이 되었을때 요청을 보내게 하기 위해 LifecycleObserver를 사용중인데 이렇게 사용하는 방식 사용해도 되는지 궁금합니다. 더 좋은 방법이 있다면 알려주세요