### PR TITLE
🔀 :: (#59) android.yml branch 네이밍 변경

### DIFF
--- a/.github/workflows/android.yml
+++ b/.github/workflows/android.yml
@@ -3,11 +3,11 @@ name: Android CI
 on:
   push:
     branches: 
-       - main
+       - master
        - develop
   pull_request:
     branches:
-       - main
+       - master
        - develop
 
 jobs:


### PR DESCRIPTION
## 💡 개요
repository는 master의 이름을 가지고 있는데 android.yml에서는 main을 등록함
## 📃 작업내용
android.yml의 main branch네이밍을 master로 변경했습니다
## 🙋‍♂️ 질문사항
제가 잘못 구현했거나 컨벤션에 맞지 않는다면 알려주세요.