### PR TITLE
🔀 :: (#202) 비동기 함수 처리 키워드 및 로직 수정

### DIFF
--- a/core/data/src/main/java/com/msg/data/repository/activity/ActivityRepository.kt
+++ b/core/data/src/main/java/com/msg/data/repository/activity/ActivityRepository.kt
@@ -8,13 +8,13 @@ import java.util.UUID
 
 
 interface ActivityRepository {
-    suspend fun addStudentActivityInfo(body: StudentActivityModel): Flow<Unit>
-    suspend fun editStudentActivityInfo(id: UUID, body: StudentActivityModel): Flow<Unit>
-    suspend fun approveStudentActivityInfo(id: UUID): Flow<Unit>
-    suspend fun rejectStudentActivityInfo(id: UUID): Flow<Unit>
-    suspend fun deleteStudentActivityInfo(id: UUID): Flow<Unit>
-    suspend fun getMyStudentActivityInfoList(page: Int, size: Int): Flow<GetStudentActivityListResponse>
-    suspend fun getStudentActivityInfoList(page: Int, size: Int, id: UUID): Flow<GetStudentActivityListResponse>
-    suspend fun getEntireStudentActivityInfoList(page: Int, size: Int): Flow<GetStudentActivityListResponse>
-    suspend fun getDetailStudentActivityInfo(id: UUID): Flow<GetDetailStudentActivityInfoResponse>
+    fun addStudentActivityInfo(body: StudentActivityModel): Flow<Unit>
+    fun editStudentActivityInfo(id: UUID, body: StudentActivityModel): Flow<Unit>
+    fun approveStudentActivityInfo(id: UUID): Flow<Unit>
+    fun rejectStudentActivityInfo(id: UUID): Flow<Unit>
+    fun deleteStudentActivityInfo(id: UUID): Flow<Unit>
+    fun getMyStudentActivityInfoList(page: Int, size: Int): Flow<GetStudentActivityListResponse>
+    fun getStudentActivityInfoList(page: Int, size: Int, id: UUID): Flow<GetStudentActivityListResponse>
+    fun getEntireStudentActivityInfoList(page: Int, size: Int): Flow<GetStudentActivityListResponse>
+    fun getDetailStudentActivityInfo(id: UUID): Flow<GetDetailStudentActivityInfoResponse>
 }

--- a/core/data/src/main/java/com/msg/data/repository/activity/ActivityRepositoryImpl.kt
+++ b/core/data/src/main/java/com/msg/data/repository/activity/ActivityRepositoryImpl.kt
@@ -11,38 +11,38 @@ import javax.inject.Inject
 class ActivityRepositoryImpl @Inject constructor(
     private val activityDataSource: ActivityDataSource
 ) : ActivityRepository {
-    override suspend fun addStudentActivityInfo(body: StudentActivityModel): Flow<Unit> {
+    override fun addStudentActivityInfo(body: StudentActivityModel): Flow<Unit> {
         return activityDataSource.addStudentActivityInfo(
             body = body
         )
     }
 
-    override suspend fun editStudentActivityInfo(id: UUID, body: StudentActivityModel): Flow<Unit> {
+    override fun editStudentActivityInfo(id: UUID, body: StudentActivityModel): Flow<Unit> {
         return activityDataSource.editStudentActivityInfo(
             id = id,
             body = body
         )
     }
 
-    override suspend fun approveStudentActivityInfo(id: UUID): Flow<Unit> {
+    override fun approveStudentActivityInfo(id: UUID): Flow<Unit> {
         return activityDataSource.approveStudentActivityInfo(
             id = id
         )
     }
 
-    override suspend fun rejectStudentActivityInfo(id: UUID): Flow<Unit> {
+    override fun rejectStudentActivityInfo(id: UUID): Flow<Unit> {
         return activityDataSource.rejectStudentActivityInfo(
             id = id
         )
     }
 
-    override suspend fun deleteStudentActivityInfo(id: UUID): Flow<Unit> {
+    override fun deleteStudentActivityInfo(id: UUID): Flow<Unit> {
         return activityDataSource.deleteStudentActivityInfo(
             id = id
         )
     }
 
-    override suspend fun getMyStudentActivityInfoList(
+    override fun getMyStudentActivityInfoList(
         page: Int,
         size: Int,
     ): Flow<GetStudentActivityListResponse> {
@@ -52,7 +52,7 @@ class ActivityRepositoryImpl @Inject constructor(
         )
     }
 
-    override suspend fun getStudentActivityInfoList(
+    override fun getStudentActivityInfoList(
         page: Int,
         size: Int,
         id: UUID
@@ -64,7 +64,7 @@ class ActivityRepositoryImpl @Inject constructor(
         )
     }
 
-    override suspend fun getEntireStudentActivityInfoList(
+    override fun getEntireStudentActivityInfoList(
         page: Int,
         size: Int,
     ): Flow<GetStudentActivityListResponse> {
@@ -74,7 +74,7 @@ class ActivityRepositoryImpl @Inject constructor(
         )
     }
 
-    override suspend fun getDetailStudentActivityInfo(id: UUID): Flow<GetDetailStudentActivityInfoResponse> {
+    override fun getDetailStudentActivityInfo(id: UUID): Flow<GetDetailStudentActivityInfoResponse> {
         return activityDataSource.getDetailStudentActivityInfo(
             id = id
         )

--- a/core/data/src/main/java/com/msg/data/repository/admin/AdminRepository.kt
+++ b/core/data/src/main/java/com/msg/data/repository/admin/AdminRepository.kt
@@ -5,5 +5,5 @@ import com.msg.model.remote.response.admin.UserListResponse
 import kotlinx.coroutines.flow.Flow
 
 interface AdminRepository {
-    suspend fun getUserList(body: GetUserListRequest, keyword: String): Flow<UserListResponse>
+    fun getUserList(body: GetUserListRequest, keyword: String): Flow<UserListResponse>
 }

--- a/core/data/src/main/java/com/msg/data/repository/admin/AdminRepositoryImpl.kt
+++ b/core/data/src/main/java/com/msg/data/repository/admin/AdminRepositoryImpl.kt
@@ -9,7 +9,7 @@ import javax.inject.Inject
 class AdminRepositoryImpl @Inject constructor(
     private val adminDataSource: AdminDataSource,
 ) : AdminRepository {
-    override suspend fun getUserList(
+    override fun getUserList(
         body: GetUserListRequest,
         keyword: String,
     ): Flow<UserListResponse> {

--- a/core/data/src/main/java/com/msg/data/repository/auth/AuthRepository.kt
+++ b/core/data/src/main/java/com/msg/data/repository/auth/AuthRepository.kt
@@ -13,7 +13,7 @@ import kotlinx.coroutines.flow.Flow
 
 interface AuthRepository {
     fun login(body: LoginRequest): Flow<AuthTokenModel>
-    suspend fun saveToken(data: AuthTokenModel)
+    fun saveToken(data: AuthTokenModel): Flow<Unit>
     fun signUpStudent(body: SignUpStudentRequest): Flow<Unit>
     fun signUpJobClubTeacher(body: SignUpJobClubTeacherRequest): Flow<Unit>
     fun signUpProfessor(body: SignUpProfessorRequest): Flow<Unit>

--- a/core/data/src/main/java/com/msg/data/repository/auth/AuthRepository.kt
+++ b/core/data/src/main/java/com/msg/data/repository/auth/AuthRepository.kt
@@ -12,15 +12,15 @@ import com.msg.model.remote.request.auth.SignUpStudentRequest
 import kotlinx.coroutines.flow.Flow
 
 interface AuthRepository {
-    suspend fun login(body: LoginRequest): Flow<AuthTokenModel>
+    fun login(body: LoginRequest): Flow<AuthTokenModel>
     suspend fun saveToken(data: AuthTokenModel)
-    suspend fun signUpStudent(body: SignUpStudentRequest): Flow<Unit>
-    suspend fun signUpJobClubTeacher(body: SignUpJobClubTeacherRequest): Flow<Unit>
-    suspend fun signUpProfessor(body: SignUpProfessorRequest): Flow<Unit>
-    suspend fun signUpGovernment(body: SignUpGovernmentRequest): Flow<Unit>
-    suspend fun signUpCompanyInstructor(body: SignUpCompanyInstructorRequest): Flow<Unit>
-    suspend fun signUpBbozzakTeacher(body: SignUpBbozzakTeacherRequest): Flow<Unit>
-    suspend fun findPassword(body: FindPasswordRequest): Flow<Unit>
-    suspend fun logout(): Flow<Unit>
-    suspend fun withdraw(): Flow<Unit>
+    fun signUpStudent(body: SignUpStudentRequest): Flow<Unit>
+    fun signUpJobClubTeacher(body: SignUpJobClubTeacherRequest): Flow<Unit>
+    fun signUpProfessor(body: SignUpProfessorRequest): Flow<Unit>
+    fun signUpGovernment(body: SignUpGovernmentRequest): Flow<Unit>
+    fun signUpCompanyInstructor(body: SignUpCompanyInstructorRequest): Flow<Unit>
+    fun signUpBbozzakTeacher(body: SignUpBbozzakTeacherRequest): Flow<Unit>
+    fun findPassword(body: FindPasswordRequest): Flow<Unit>
+    fun logout(): Flow<Unit>
+    fun withdraw(): Flow<Unit>
 }

--- a/core/data/src/main/java/com/msg/data/repository/auth/AuthRepositoryImpl.kt
+++ b/core/data/src/main/java/com/msg/data/repository/auth/AuthRepositoryImpl.kt
@@ -11,6 +11,7 @@ import com.msg.model.remote.request.auth.SignUpJobClubTeacherRequest
 import com.msg.model.remote.request.auth.SignUpProfessorRequest
 import com.msg.model.remote.request.auth.SignUpStudentRequest
 import com.msg.network.datasource.auth.AuthDataSource
+import kotlinx.coroutines.coroutineScope
 import kotlinx.coroutines.flow.Flow
 import javax.inject.Inject
 
@@ -18,7 +19,7 @@ class AuthRepositoryImpl @Inject constructor(
     private val authDataSource: AuthDataSource,
     private val localDataSource: AuthTokenDataSource
 ) : AuthRepository {
-    override suspend fun login(body: LoginRequest): Flow<AuthTokenModel> {
+    override fun login(body: LoginRequest): Flow<AuthTokenModel> {
         return authDataSource.login(
             body = body
         )
@@ -34,52 +35,52 @@ class AuthRepositoryImpl @Inject constructor(
         }
     }
 
-    override suspend fun signUpStudent(body: SignUpStudentRequest): Flow<Unit> {
+    override fun signUpStudent(body: SignUpStudentRequest): Flow<Unit> {
         return authDataSource.signUpStudent(
             body = body
         )
     }
 
-    override suspend fun signUpJobClubTeacher(body: SignUpJobClubTeacherRequest): Flow<Unit> {
+    override fun signUpJobClubTeacher(body: SignUpJobClubTeacherRequest): Flow<Unit> {
         return authDataSource.signUpJobClubTeacher(
             body = body
         )
     }
 
-    override suspend fun signUpProfessor(body: SignUpProfessorRequest): Flow<Unit> {
+    override fun signUpProfessor(body: SignUpProfessorRequest): Flow<Unit> {
         return authDataSource.signUpProfessor(
             body = body
         )
     }
 
-    override suspend fun signUpGovernment(body: SignUpGovernmentRequest): Flow<Unit> {
+    override fun signUpGovernment(body: SignUpGovernmentRequest): Flow<Unit> {
         return authDataSource.signUpGovernment(
             body = body
         )
     }
 
-    override suspend fun signUpCompanyInstructor(body: SignUpCompanyInstructorRequest): Flow<Unit> {
+    override fun signUpCompanyInstructor(body: SignUpCompanyInstructorRequest): Flow<Unit> {
         return authDataSource.signUpCompanyInstructor(
             body = body
         )
     }
 
-    override suspend fun signUpBbozzakTeacher(body: SignUpBbozzakTeacherRequest): Flow<Unit> {
+    override fun signUpBbozzakTeacher(body: SignUpBbozzakTeacherRequest): Flow<Unit> {
         return authDataSource.signUpBbozzakTeacher(
             body = body
         )
     }
 
-    override suspend fun findPassword(body: FindPasswordRequest): Flow<Unit> {
+    override fun findPassword(body: FindPasswordRequest): Flow<Unit> {
         return authDataSource.findPassword(
             body = body
         )
     }
-    override suspend fun logout(): Flow<Unit> {
+    override fun logout(): Flow<Unit> {
         return authDataSource.logout()
     }
 
-    override suspend fun withdraw(): Flow<Unit> {
+    override fun withdraw(): Flow<Unit> {
         return authDataSource.withdraw()
     }
 }

--- a/core/data/src/main/java/com/msg/data/repository/auth/AuthRepositoryImpl.kt
+++ b/core/data/src/main/java/com/msg/data/repository/auth/AuthRepositoryImpl.kt
@@ -13,6 +13,8 @@ import com.msg.model.remote.request.auth.SignUpStudentRequest
 import com.msg.network.datasource.auth.AuthDataSource
 import kotlinx.coroutines.coroutineScope
 import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.first
+import kotlinx.coroutines.flow.flow
 import javax.inject.Inject
 
 class AuthRepositoryImpl @Inject constructor(
@@ -25,14 +27,12 @@ class AuthRepositoryImpl @Inject constructor(
         )
     }
 
-    override suspend fun saveToken(data: AuthTokenModel) {
-        data.let { loginResponse ->
-            localDataSource.setAccessToken(loginResponse.accessToken)
-            localDataSource.setAccessTokenExp(loginResponse.accessExpiredAt)
-            localDataSource.setRefreshToken(loginResponse.refreshToken)
-            localDataSource.setRefreshTokenExp(loginResponse.refreshExpiredAt)
-            localDataSource.setAuthority(loginResponse.authority)
-        }
+    override fun saveToken(data: AuthTokenModel): Flow<Unit> = flow {
+            localDataSource.setAccessToken(data.accessToken).first()
+            localDataSource.setAccessTokenExp(data.accessExpiredAt).first()
+            localDataSource.setRefreshToken(data.refreshToken).first()
+            localDataSource.setRefreshTokenExp(data.refreshExpiredAt).first()
+            localDataSource.setAuthority(data.authority).first()
     }
 
     override fun signUpStudent(body: SignUpStudentRequest): Flow<Unit> {

--- a/core/data/src/main/java/com/msg/data/repository/certification/CertificationRepository.kt
+++ b/core/data/src/main/java/com/msg/data/repository/certification/CertificationRepository.kt
@@ -6,8 +6,8 @@ import kotlinx.coroutines.flow.Flow
 import java.util.UUID
 
 interface CertificationRepository {
-    suspend fun getCertificationListForTeacher(studentId: UUID): Flow<List<CertificationListResponse>>
-    suspend fun getCertificationListForStudent(): Flow<List<CertificationListResponse>>
-    suspend fun writeCertification(body: WriteCertificationRequest): Flow<Unit>
-    suspend fun editCertification(id: UUID, body: WriteCertificationRequest): Flow<Unit>
+    fun getCertificationListForTeacher(studentId: UUID): Flow<List<CertificationListResponse>>
+    fun getCertificationListForStudent(): Flow<List<CertificationListResponse>>
+    fun writeCertification(body: WriteCertificationRequest): Flow<Unit>
+    fun editCertification(id: UUID, body: WriteCertificationRequest): Flow<Unit>
 }

--- a/core/data/src/main/java/com/msg/data/repository/certification/CertificationRepositoryImpl.kt
+++ b/core/data/src/main/java/com/msg/data/repository/certification/CertificationRepositoryImpl.kt
@@ -10,21 +10,21 @@ import javax.inject.Inject
 class CertificationRepositoryImpl @Inject constructor(
     private val certificationDataSource: CertificationDataSource,
 ) : CertificationRepository {
-    override suspend fun getCertificationListForTeacher(studentId: UUID): Flow<List<CertificationListResponse>> {
+    override fun getCertificationListForTeacher(studentId: UUID): Flow<List<CertificationListResponse>> {
         return certificationDataSource.getCertificationListForTeacher(studentId = studentId)
     }
 
-    override suspend fun getCertificationListForStudent(): Flow<List<CertificationListResponse>> {
+    override fun getCertificationListForStudent(): Flow<List<CertificationListResponse>> {
         return certificationDataSource.getCertificationListForStudent()
     }
 
-    override suspend fun writeCertification(body: WriteCertificationRequest): Flow<Unit> {
+    override fun writeCertification(body: WriteCertificationRequest): Flow<Unit> {
         return certificationDataSource.writeCertification(
             body = body
         )
     }
 
-    override suspend fun editCertification(
+    override fun editCertification(
         id: UUID,
         body: WriteCertificationRequest,
     ): Flow<Unit> {

--- a/core/data/src/main/java/com/msg/data/repository/club/ClubRepository.kt
+++ b/core/data/src/main/java/com/msg/data/repository/club/ClubRepository.kt
@@ -8,8 +8,8 @@ import kotlinx.coroutines.flow.Flow
 import java.util.UUID
 
 interface ClubRepository {
-    suspend fun getClubList(highSchool: HighSchool): Flow<List<ClubListResponse>>
-    suspend fun getClubDetail(id: Long): Flow<ClubDetailResponse>
-    suspend fun getStudentBelongClubDetail(id: Long, studentId: UUID): Flow<StudentBelongClubResponse>
-    suspend fun getMyClubDetail(): Flow<ClubDetailResponse>
+    fun getClubList(highSchool: HighSchool): Flow<List<ClubListResponse>>
+    fun getClubDetail(id: Long): Flow<ClubDetailResponse>
+    fun getStudentBelongClubDetail(id: Long, studentId: UUID): Flow<StudentBelongClubResponse>
+    fun getMyClubDetail(): Flow<ClubDetailResponse>
 }

--- a/core/data/src/main/java/com/msg/data/repository/club/ClubRepositoryImpl.kt
+++ b/core/data/src/main/java/com/msg/data/repository/club/ClubRepositoryImpl.kt
@@ -12,22 +12,22 @@ import javax.inject.Inject
 class ClubRepositoryImpl @Inject constructor(
     private val clubDataSource: ClubDataSource
 ) : ClubRepository{
-    override suspend fun getClubList(highSchool: HighSchool): Flow<List<ClubListResponse>> {
+    override fun getClubList(highSchool: HighSchool): Flow<List<ClubListResponse>> {
         return clubDataSource.getClubList(highSchool = highSchool)
     }
 
-    override suspend fun getClubDetail(id: Long): Flow<ClubDetailResponse> {
+    override fun getClubDetail(id: Long): Flow<ClubDetailResponse> {
         return clubDataSource.getClubDetail(id = id)
     }
 
-    override suspend fun getStudentBelongClubDetail(
+    override fun getStudentBelongClubDetail(
         id: Long,
         studentId: UUID
     ): Flow<StudentBelongClubResponse> {
         return clubDataSource.getStudentBelongClubDetail(id = id, studentId = studentId)
     }
 
-    override suspend fun getMyClubDetail(): Flow<ClubDetailResponse> {
+    override fun getMyClubDetail(): Flow<ClubDetailResponse> {
         return clubDataSource.getMyClubDetail()
     }
 }

--- a/core/data/src/main/java/com/msg/data/repository/email/EmailRepository.kt
+++ b/core/data/src/main/java/com/msg/data/repository/email/EmailRepository.kt
@@ -5,6 +5,6 @@ import com.msg.model.remote.response.email.GetEmailAuthenticateStatusResponse
 import kotlinx.coroutines.flow.Flow
 
 interface EmailRepository {
-    suspend fun sendLinkToEmail(body: SendLinkToEmailRequest): Flow<Unit>
-    suspend fun getEmailAuthenticateStatus(email: String): Flow<GetEmailAuthenticateStatusResponse>
+    fun sendLinkToEmail(body: SendLinkToEmailRequest): Flow<Unit>
+    fun getEmailAuthenticateStatus(email: String): Flow<GetEmailAuthenticateStatusResponse>
 }

--- a/core/data/src/main/java/com/msg/data/repository/email/EmailRepositoryImpl.kt
+++ b/core/data/src/main/java/com/msg/data/repository/email/EmailRepositoryImpl.kt
@@ -9,13 +9,13 @@ import javax.inject.Inject
 class EmailRepositoryImpl @Inject constructor(
     private val emailDataSource: EmailDataSource
 ) : EmailRepository {
-    override suspend fun sendLinkToEmail(body: SendLinkToEmailRequest): Flow<Unit> {
+    override fun sendLinkToEmail(body: SendLinkToEmailRequest): Flow<Unit> {
         return emailDataSource.sendLinkToEmail(
             body = body
         )
     }
 
-    override suspend fun getEmailAuthenticateStatus(email: String): Flow<GetEmailAuthenticateStatusResponse> {
+    override fun getEmailAuthenticateStatus(email: String): Flow<GetEmailAuthenticateStatusResponse> {
         return emailDataSource.getEmailAuthenticateStatus(
             email = email
         )

--- a/core/data/src/main/java/com/msg/data/repository/faq/FaqRepository.kt
+++ b/core/data/src/main/java/com/msg/data/repository/faq/FaqRepository.kt
@@ -5,6 +5,6 @@ import com.msg.model.remote.response.faq.GetFrequentlyAskedQuestionDetailRespons
 import kotlinx.coroutines.flow.Flow
 
 interface FaqRepository {
-    suspend fun addFrequentlyAskedQuestions(body: AddFrequentlyAskedQuestionsRequest): Flow<Unit>
-    suspend fun getFrequentlyAskedQuestionsList(): Flow<List<GetFrequentlyAskedQuestionDetailResponse>>
+    fun addFrequentlyAskedQuestions(body: AddFrequentlyAskedQuestionsRequest): Flow<Unit>
+    fun getFrequentlyAskedQuestionsList(): Flow<List<GetFrequentlyAskedQuestionDetailResponse>>
 }

--- a/core/data/src/main/java/com/msg/data/repository/faq/FaqRepositoryImpl.kt
+++ b/core/data/src/main/java/com/msg/data/repository/faq/FaqRepositoryImpl.kt
@@ -9,13 +9,13 @@ import javax.inject.Inject
 class FaqRepositoryImpl @Inject constructor(
     private val faqDataSource: FaqDataSource,
 ) : FaqRepository {
-    override suspend fun addFrequentlyAskedQuestions(body: AddFrequentlyAskedQuestionsRequest): Flow<Unit> {
+    override fun addFrequentlyAskedQuestions(body: AddFrequentlyAskedQuestionsRequest): Flow<Unit> {
         return faqDataSource.addFrequentlyAskedQuestions(
             body = body
         )
     }
 
-    override suspend fun getFrequentlyAskedQuestionsList(): Flow<List<GetFrequentlyAskedQuestionDetailResponse>> {
+    override fun getFrequentlyAskedQuestionsList(): Flow<List<GetFrequentlyAskedQuestionDetailResponse>> {
         return faqDataSource.getFrequentlyAskedQuestionsList()
     }
 }

--- a/core/data/src/main/java/com/msg/data/repository/lecture/LectureRepository.kt
+++ b/core/data/src/main/java/com/msg/data/repository/lecture/LectureRepository.kt
@@ -14,17 +14,17 @@ import kotlinx.coroutines.flow.Flow
 import java.util.UUID
 
 interface LectureRepository {
-    suspend fun openLecture(body: OpenLectureRequest): Flow<Unit>
-    suspend fun getLectureList(page: Int, size: Int, type: String?): Flow<LectureListResponse>
-    suspend fun getDetailLecture(id: UUID): Flow<DetailLectureResponse>
-    suspend fun lectureApplication(id: UUID): Flow<Unit>
-    suspend fun lectureApplicationCancel(id: UUID): Flow<Unit>
-    suspend fun searchProfessor(keyword: String): Flow<SearchProfessorResponse>
-    suspend fun searchLine(keyword: String, division: String): Flow<SearchLineResponse>
-    suspend fun searchDepartment(keyword: String): Flow<SearchDepartmentResponse>
-    suspend fun searchDivision(keyword: String): Flow<SearchDivisionResponse>
-    suspend fun getLectureSignUpHistory(studentId: UUID): Flow<GetLectureSignUpHistoryResponse>
-    suspend fun getTakingLectureStudentList(id: UUID): Flow<GetTakingLectureStudentListResponse>
-    suspend fun editLectureCourseCompletionStatus(id: UUID, studentId: UUID, isComplete: Boolean): Flow<Unit>
-    suspend fun downloadExcelFile(): Flow<DownloadExcelFileResponse>
+    fun openLecture(body: OpenLectureRequest): Flow<Unit>
+    fun getLectureList(page: Int, size: Int, type: String?): Flow<LectureListResponse>
+    fun getDetailLecture(id: UUID): Flow<DetailLectureResponse>
+    fun lectureApplication(id: UUID): Flow<Unit>
+    fun lectureApplicationCancel(id: UUID): Flow<Unit>
+    fun searchProfessor(keyword: String): Flow<SearchProfessorResponse>
+    fun searchLine(keyword: String, division: String): Flow<SearchLineResponse>
+    fun searchDepartment(keyword: String): Flow<SearchDepartmentResponse>
+    fun searchDivision(keyword: String): Flow<SearchDivisionResponse>
+    fun getLectureSignUpHistory(studentId: UUID): Flow<GetLectureSignUpHistoryResponse>
+    fun getTakingLectureStudentList(id: UUID): Flow<GetTakingLectureStudentListResponse>
+    fun editLectureCourseCompletionStatus(id: UUID, studentId: UUID, isComplete: Boolean): Flow<Unit>
+    fun downloadExcelFile(): Flow<DownloadExcelFileResponse>
 }

--- a/core/data/src/main/java/com/msg/data/repository/lecture/LectureRepositoryImpl.kt
+++ b/core/data/src/main/java/com/msg/data/repository/lecture/LectureRepositoryImpl.kt
@@ -18,13 +18,13 @@ import javax.inject.Inject
 class LectureRepositoryImpl @Inject constructor(
     private val lectureDataSource: LectureDataSource,
 ) : LectureRepository {
-    override suspend fun openLecture(body: OpenLectureRequest): Flow<Unit> {
+    override fun openLecture(body: OpenLectureRequest): Flow<Unit> {
         return lectureDataSource.openLecture(
             body = body
         )
     }
 
-    override suspend fun getLectureList(
+    override fun getLectureList(
         page: Int,
         size: Int,
         type: String?,
@@ -36,62 +36,62 @@ class LectureRepositoryImpl @Inject constructor(
         )
     }
 
-    override suspend fun getDetailLecture(id: UUID): Flow<DetailLectureResponse> {
+    override fun getDetailLecture(id: UUID): Flow<DetailLectureResponse> {
         return lectureDataSource.getDetailLecture(
             id = id
         )
     }
 
-    override suspend fun lectureApplication(id: UUID): Flow<Unit> {
+    override fun lectureApplication(id: UUID): Flow<Unit> {
         return lectureDataSource.lectureApplication(
             id = id
         )
     }
 
-    override suspend fun lectureApplicationCancel(id: UUID): Flow<Unit> {
+    override fun lectureApplicationCancel(id: UUID): Flow<Unit> {
         return lectureDataSource.lectureApplicationCancel(
             id = id
         )
     }
 
-    override suspend fun searchProfessor(keyword: String): Flow<SearchProfessorResponse> {
+    override fun searchProfessor(keyword: String): Flow<SearchProfessorResponse> {
         return lectureDataSource.searchProfessor(
             keyword = keyword
         )
     }
 
-    override suspend fun searchLine(keyword: String, division: String): Flow<SearchLineResponse> {
+    override fun searchLine(keyword: String, division: String): Flow<SearchLineResponse> {
         return lectureDataSource.searchLine(
             keyword = keyword,
             division = division
         )
     }
 
-    override suspend fun searchDepartment(keyword: String): Flow<SearchDepartmentResponse> {
+    override fun searchDepartment(keyword: String): Flow<SearchDepartmentResponse> {
         return lectureDataSource.searchDepartment(
             keyword = keyword
         )
     }
 
-    override suspend fun searchDivision(keyword: String): Flow<SearchDivisionResponse> {
+    override fun searchDivision(keyword: String): Flow<SearchDivisionResponse> {
         return lectureDataSource.searchDivision(
             keyword = keyword
         )
     }
 
-    override suspend fun getLectureSignUpHistory(studentId: UUID): Flow<GetLectureSignUpHistoryResponse> {
+    override fun getLectureSignUpHistory(studentId: UUID): Flow<GetLectureSignUpHistoryResponse> {
         return lectureDataSource.getLectureSignUpHistory(
             studentId = studentId
         )
     }
 
-    override suspend fun getTakingLectureStudentList(id: UUID): Flow<GetTakingLectureStudentListResponse> {
+    override fun getTakingLectureStudentList(id: UUID): Flow<GetTakingLectureStudentListResponse> {
         return lectureDataSource.getTakingLectureStudentList(
             id = id
         )
     }
 
-    override suspend fun editLectureCourseCompletionStatus(id: UUID, studentId: UUID, isComplete: Boolean): Flow<Unit> {
+    override fun editLectureCourseCompletionStatus(id: UUID, studentId: UUID, isComplete: Boolean): Flow<Unit> {
         return lectureDataSource.editLectureCourseCompletionStatus(
             id = id,
             studentId = studentId,
@@ -99,7 +99,7 @@ class LectureRepositoryImpl @Inject constructor(
         )
     }
 
-    override suspend fun downloadExcelFile(): Flow<DownloadExcelFileResponse> {
+    override fun downloadExcelFile(): Flow<DownloadExcelFileResponse> {
         return lectureDataSource.downloadExcelFile()
     }
 }

--- a/core/data/src/main/java/com/msg/data/repository/post/PostRepository.kt
+++ b/core/data/src/main/java/com/msg/data/repository/post/PostRepository.kt
@@ -8,9 +8,9 @@ import kotlinx.coroutines.flow.Flow
 import java.util.UUID
 
 interface PostRepository {
-    suspend fun sendPost(body: WritePostRequest): Flow<Unit>
-    suspend fun getPostList(type: FeedType, size: Int, page: Int): Flow<GetPostListResponse>
-    suspend fun getDetailPost(id: UUID): Flow<GetDetailPostResponse>
-    suspend fun editPost(id: UUID, body: WritePostRequest): Flow<Unit>
-    suspend fun deletePost(id: UUID): Flow<Unit>
+    fun sendPost(body: WritePostRequest): Flow<Unit>
+    fun getPostList(type: FeedType, size: Int, page: Int): Flow<GetPostListResponse>
+    fun getDetailPost(id: UUID): Flow<GetDetailPostResponse>
+    fun editPost(id: UUID, body: WritePostRequest): Flow<Unit>
+    fun deletePost(id: UUID): Flow<Unit>
 }

--- a/core/data/src/main/java/com/msg/data/repository/post/PostRepositoryImpl.kt
+++ b/core/data/src/main/java/com/msg/data/repository/post/PostRepositoryImpl.kt
@@ -12,11 +12,11 @@ import javax.inject.Inject
 class PostRepositoryImpl @Inject constructor(
     private val postDataSource: PostDataSource
 ) : PostRepository {
-    override suspend fun sendPost(body: WritePostRequest): Flow<Unit> {
+    override fun sendPost(body: WritePostRequest): Flow<Unit> {
         return postDataSource.sendPost(body = body)
     }
 
-    override suspend fun getPostList(
+    override fun getPostList(
         type: FeedType,
         size: Int,
         page: Int
@@ -28,18 +28,18 @@ class PostRepositoryImpl @Inject constructor(
         )
     }
 
-    override suspend fun getDetailPost(id: UUID): Flow<GetDetailPostResponse> {
+    override fun getDetailPost(id: UUID): Flow<GetDetailPostResponse> {
         return postDataSource.getDetailPost(id = id)
     }
 
-    override suspend fun editPost(id: UUID, body: WritePostRequest): Flow<Unit> {
+    override fun editPost(id: UUID, body: WritePostRequest): Flow<Unit> {
         return postDataSource.editPost(
             id = id,
             body = body
         )
     }
 
-    override suspend fun deletePost(id: UUID): Flow<Unit> {
+    override fun deletePost(id: UUID): Flow<Unit> {
         return postDataSource.deletePost(id = id)
     }
 }

--- a/core/data/src/main/java/com/msg/data/repository/user/UserRepository.kt
+++ b/core/data/src/main/java/com/msg/data/repository/user/UserRepository.kt
@@ -5,6 +5,6 @@ import com.msg.model.remote.response.user.InquiryMyPageResponse
 import kotlinx.coroutines.flow.Flow
 
 interface UserRepository {
-    suspend fun changePassword(body: ChangePasswordRequest): Flow<Unit>
-    suspend fun inquiryMyPage(): Flow<InquiryMyPageResponse>
+    fun changePassword(body: ChangePasswordRequest): Flow<Unit>
+    fun inquiryMyPage(): Flow<InquiryMyPageResponse>
 }

--- a/core/data/src/main/java/com/msg/data/repository/user/UserRepositoryImpl.kt
+++ b/core/data/src/main/java/com/msg/data/repository/user/UserRepositoryImpl.kt
@@ -9,11 +9,11 @@ import javax.inject.Inject
 class UserRepositoryImpl @Inject constructor(
     private val userDataSource: UserDataSource
 ) : UserRepository {
-    override suspend fun changePassword(body: ChangePasswordRequest): Flow<Unit> {
+    override fun changePassword(body: ChangePasswordRequest): Flow<Unit> {
         return userDataSource.changePassword(body = body)
     }
 
-    override suspend fun inquiryMyPage(): Flow<InquiryMyPageResponse> {
+    override fun inquiryMyPage(): Flow<InquiryMyPageResponse> {
         return userDataSource.inquiryMyPage()
     }
 }

--- a/core/datastore/src/main/java/com/msg/datastore/AuthTokenDataSource.kt
+++ b/core/datastore/src/main/java/com/msg/datastore/AuthTokenDataSource.kt
@@ -3,6 +3,7 @@ package com.msg.datastore
 import androidx.datastore.core.DataStore
 import Authority
 import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.flow
 import kotlinx.coroutines.flow.map
 import kotlinx.coroutines.flow.mapNotNull
 import java.time.LocalDateTime
@@ -15,12 +16,13 @@ class AuthTokenDataSource @Inject constructor(
         it.accessToken ?: ""
     }
 
-    suspend fun setAccessToken(accessToken: String) {
+    fun setAccessToken(accessToken: String): Flow<Unit> = flow {
         authToken.updateData {
             it.toBuilder()
                 .setAccessToken(accessToken)
                 .build()
         }
+        emit(Unit)
     }
 
     fun getAccessTokenExp(): Flow<LocalDateTime> =
@@ -29,24 +31,26 @@ class AuthTokenDataSource @Inject constructor(
         }
 
 
-    suspend fun setAccessTokenExp(accessTokenExp: String) {
+    fun setAccessTokenExp(accessTokenExp: String): Flow<Unit> = flow {
         authToken.updateData {
             it.toBuilder()
                 .setAccessExp(accessTokenExp)
                 .build()
         }
+        emit(Unit)
     }
 
     fun getRefreshToken(): Flow<String> = authToken.data.map {
         it.refreshToken ?: ""
     }
 
-    suspend fun setRefreshToken(refreshToken: String) {
+    fun setRefreshToken(refreshToken: String): Flow<Unit> = flow {
         authToken.updateData {
             it.toBuilder()
                 .setRefreshToken(refreshToken)
                 .build()
         }
+        emit(Unit)
     }
 
     fun getRefreshTokenExp(): Flow<LocalDateTime> =
@@ -55,7 +59,7 @@ class AuthTokenDataSource @Inject constructor(
         } }
 
 
-    suspend fun setRefreshTokenExp(refreshTokenExp: String) {
+    fun setRefreshTokenExp(refreshTokenExp: String): Flow<Unit> = flow {
         authToken.updateData {
             it.toBuilder()
                 .setRefreshExp(refreshTokenExp)
@@ -80,11 +84,12 @@ class AuthTokenDataSource @Inject constructor(
     }
 
 
-    suspend fun setAuthority(authority: Authority) {
+    fun setAuthority(authority: Authority): Flow<Unit> = flow {
         authToken.updateData {
             it.toBuilder()
                 .setAuthority(authority.toString())
                 .build()
         }
+        emit(Unit)
     }
 }

--- a/core/network/src/main/java/com/msg/network/datasource/activity/ActivityDataSource.kt
+++ b/core/network/src/main/java/com/msg/network/datasource/activity/ActivityDataSource.kt
@@ -7,13 +7,13 @@ import kotlinx.coroutines.flow.Flow
 import java.util.UUID
 
 interface ActivityDataSource {
-    suspend fun addStudentActivityInfo(body: StudentActivityModel): Flow<Unit>
-    suspend fun editStudentActivityInfo(id: UUID, body: StudentActivityModel): Flow<Unit>
-    suspend fun approveStudentActivityInfo(id: UUID): Flow<Unit>
-    suspend fun rejectStudentActivityInfo(id: UUID): Flow<Unit>
-    suspend fun deleteStudentActivityInfo(id: UUID): Flow<Unit>
-    suspend fun getMyStudentActivityInfoList(page: Int, size: Int): Flow<GetStudentActivityListResponse>
-    suspend fun getStudentActivityInfoList(page: Int, size: Int, id: UUID): Flow<GetStudentActivityListResponse>
-    suspend fun getEntireStudentActivityInfoList(page: Int, size: Int): Flow<GetStudentActivityListResponse>
-    suspend fun getDetailStudentActivityInfo(id: UUID): Flow<GetDetailStudentActivityInfoResponse>
+    fun addStudentActivityInfo(body: StudentActivityModel): Flow<Unit>
+    fun editStudentActivityInfo(id: UUID, body: StudentActivityModel): Flow<Unit>
+    fun approveStudentActivityInfo(id: UUID): Flow<Unit>
+    fun rejectStudentActivityInfo(id: UUID): Flow<Unit>
+    fun deleteStudentActivityInfo(id: UUID): Flow<Unit>
+    fun getMyStudentActivityInfoList(page: Int, size: Int): Flow<GetStudentActivityListResponse>
+    fun getStudentActivityInfoList(page: Int, size: Int, id: UUID): Flow<GetStudentActivityListResponse>
+    fun getEntireStudentActivityInfoList(page: Int, size: Int): Flow<GetStudentActivityListResponse>
+    fun getDetailStudentActivityInfo(id: UUID): Flow<GetDetailStudentActivityInfoResponse>
 }

--- a/core/network/src/main/java/com/msg/network/datasource/activity/ActivityDataSourceImpl.kt
+++ b/core/network/src/main/java/com/msg/network/datasource/activity/ActivityDataSourceImpl.kt
@@ -15,7 +15,7 @@ import javax.inject.Inject
 class ActivityDataSourceImpl @Inject constructor(
     private val activityAPI: ActivityAPI
 ) : ActivityDataSource {
-    override suspend fun addStudentActivityInfo(body: StudentActivityModel): Flow<Unit> = flow {
+    override fun addStudentActivityInfo(body: StudentActivityModel): Flow<Unit> = flow {
         emit(
             BitgoeulApiHandler<Unit>()
                 .httpRequest { activityAPI.addStudentActivityInfo(body = body) }
@@ -23,7 +23,7 @@ class ActivityDataSourceImpl @Inject constructor(
         )
     }.flowOn(Dispatchers.IO)
 
-    override suspend fun editStudentActivityInfo(id: UUID, body: StudentActivityModel): Flow<Unit> = flow {
+    override fun editStudentActivityInfo(id: UUID, body: StudentActivityModel): Flow<Unit> = flow {
         emit(
             BitgoeulApiHandler<Unit>()
                 .httpRequest { activityAPI.editStudentActivityInfo(id = id, body = body) }
@@ -31,7 +31,7 @@ class ActivityDataSourceImpl @Inject constructor(
         )
     }.flowOn(Dispatchers.IO)
 
-    override suspend fun approveStudentActivityInfo(id: UUID): Flow<Unit> = flow {
+    override fun approveStudentActivityInfo(id: UUID): Flow<Unit> = flow {
         emit(
             BitgoeulApiHandler<Unit>()
                 .httpRequest { activityAPI.approveStudentActivityInfo(id = id) }
@@ -39,7 +39,7 @@ class ActivityDataSourceImpl @Inject constructor(
         )
     }.flowOn(Dispatchers.IO)
 
-    override suspend fun rejectStudentActivityInfo(id: UUID): Flow<Unit> = flow {
+    override fun rejectStudentActivityInfo(id: UUID): Flow<Unit> = flow {
         emit(
             BitgoeulApiHandler<Unit>()
                 .httpRequest { activityAPI.rejectStudentActivityInfo(id = id) }
@@ -47,7 +47,7 @@ class ActivityDataSourceImpl @Inject constructor(
         )
     }.flowOn(Dispatchers.IO)
 
-    override suspend fun deleteStudentActivityInfo(id: UUID): Flow<Unit> = flow {
+    override fun deleteStudentActivityInfo(id: UUID): Flow<Unit> = flow {
         emit(
             BitgoeulApiHandler<Unit>()
                 .httpRequest { activityAPI.deleteStudentActivityInfo(id = id) }
@@ -55,7 +55,7 @@ class ActivityDataSourceImpl @Inject constructor(
         )
     }.flowOn(Dispatchers.IO)
 
-    override suspend fun getMyStudentActivityInfoList(
+    override fun getMyStudentActivityInfoList(
         page: Int,
         size: Int,
     ): Flow<GetStudentActivityListResponse> = flow {
@@ -66,7 +66,7 @@ class ActivityDataSourceImpl @Inject constructor(
         )
     }.flowOn(Dispatchers.IO)
 
-    override suspend fun getStudentActivityInfoList(
+    override fun getStudentActivityInfoList(
         page: Int,
         size: Int,
         id: UUID
@@ -78,7 +78,7 @@ class ActivityDataSourceImpl @Inject constructor(
         )
     }.flowOn(Dispatchers.IO)
 
-    override suspend fun getEntireStudentActivityInfoList(
+    override fun getEntireStudentActivityInfoList(
         page: Int,
         size: Int,
     ): Flow<GetStudentActivityListResponse> = flow {
@@ -89,7 +89,7 @@ class ActivityDataSourceImpl @Inject constructor(
         )
     }.flowOn(Dispatchers.IO)
 
-    override suspend fun getDetailStudentActivityInfo(id: UUID): Flow<GetDetailStudentActivityInfoResponse> = flow {
+    override fun getDetailStudentActivityInfo(id: UUID): Flow<GetDetailStudentActivityInfoResponse> = flow {
         emit(
             BitgoeulApiHandler<GetDetailStudentActivityInfoResponse>()
                 .httpRequest { activityAPI.getDetailStudentActivityInfo(id = id) }

--- a/core/network/src/main/java/com/msg/network/datasource/admin/AdminDataSource.kt
+++ b/core/network/src/main/java/com/msg/network/datasource/admin/AdminDataSource.kt
@@ -5,5 +5,5 @@ import com.msg.model.remote.response.admin.UserListResponse
 import kotlinx.coroutines.flow.Flow
 
 interface AdminDataSource {
-    suspend fun getUserList(body: GetUserListRequest, keyword: String): Flow<UserListResponse>
+    fun getUserList(body: GetUserListRequest, keyword: String): Flow<UserListResponse>
 }

--- a/core/network/src/main/java/com/msg/network/datasource/admin/AdminDataSourceImpl.kt
+++ b/core/network/src/main/java/com/msg/network/datasource/admin/AdminDataSourceImpl.kt
@@ -11,7 +11,7 @@ import javax.inject.Inject
 class AdminDataSourceImpl @Inject constructor(
     private val adminAPI: AdminAPI,
 ) : AdminDataSource {
-    override suspend fun getUserList(
+    override fun getUserList(
         body: GetUserListRequest,
         keyword: String,
     ): Flow<UserListResponse> = flow {

--- a/core/network/src/main/java/com/msg/network/datasource/auth/AuthDataSource.kt
+++ b/core/network/src/main/java/com/msg/network/datasource/auth/AuthDataSource.kt
@@ -12,14 +12,14 @@ import com.msg.model.remote.request.auth.SignUpStudentRequest
 import kotlinx.coroutines.flow.Flow
 
 interface AuthDataSource {
-    suspend fun login(body: LoginRequest): Flow<AuthTokenModel>
-    suspend fun signUpStudent(body: SignUpStudentRequest): Flow<Unit>
-    suspend fun signUpJobClubTeacher(body: SignUpJobClubTeacherRequest): Flow<Unit>
-    suspend fun signUpProfessor(body: SignUpProfessorRequest): Flow<Unit>
-    suspend fun signUpGovernment(body: SignUpGovernmentRequest): Flow<Unit>
-    suspend fun signUpCompanyInstructor(body: SignUpCompanyInstructorRequest): Flow<Unit>
-    suspend fun signUpBbozzakTeacher(body: SignUpBbozzakTeacherRequest): Flow<Unit>
-    suspend fun findPassword(body: FindPasswordRequest): Flow<Unit>
-    suspend fun logout(): Flow<Unit>
-    suspend fun withdraw(): Flow<Unit>
+    fun login(body: LoginRequest): Flow<AuthTokenModel>
+    fun signUpStudent(body: SignUpStudentRequest): Flow<Unit>
+    fun signUpJobClubTeacher(body: SignUpJobClubTeacherRequest): Flow<Unit>
+    fun signUpProfessor(body: SignUpProfessorRequest): Flow<Unit>
+    fun signUpGovernment(body: SignUpGovernmentRequest): Flow<Unit>
+    fun signUpCompanyInstructor(body: SignUpCompanyInstructorRequest): Flow<Unit>
+    fun signUpBbozzakTeacher(body: SignUpBbozzakTeacherRequest): Flow<Unit>
+    fun findPassword(body: FindPasswordRequest): Flow<Unit>
+    fun logout(): Flow<Unit>
+    fun withdraw(): Flow<Unit>
 }

--- a/core/network/src/main/java/com/msg/network/datasource/auth/AuthDataSourceImpl.kt
+++ b/core/network/src/main/java/com/msg/network/datasource/auth/AuthDataSourceImpl.kt
@@ -20,7 +20,7 @@ import javax.inject.Inject
 class AuthDataSourceImpl @Inject constructor(
     private val authAPI: AuthAPI
 ) : AuthDataSource {
-    override suspend fun login(body: LoginRequest): Flow<AuthTokenModel> = flow {
+    override fun login(body: LoginRequest): Flow<AuthTokenModel> = flow {
         emit(
             BitgoeulApiHandler<AuthTokenModel>()
                 .httpRequest { authAPI.login(body = body) }
@@ -28,7 +28,7 @@ class AuthDataSourceImpl @Inject constructor(
         )
     }.flowOn(Dispatchers.IO)
 
-    override suspend fun signUpStudent(body: SignUpStudentRequest): Flow<Unit> = flow {
+    override fun signUpStudent(body: SignUpStudentRequest): Flow<Unit> = flow {
         emit(
             BitgoeulApiHandler<Unit>()
                 .httpRequest { authAPI.signUpStudent(body = body) }
@@ -36,7 +36,7 @@ class AuthDataSourceImpl @Inject constructor(
         )
     }.flowOn(Dispatchers.IO)
 
-    override suspend fun signUpJobClubTeacher(body: SignUpJobClubTeacherRequest): Flow<Unit> = flow {
+    override fun signUpJobClubTeacher(body: SignUpJobClubTeacherRequest): Flow<Unit> = flow {
         emit(
             BitgoeulApiHandler<Unit>()
                 .httpRequest { authAPI.signUpJobClubTeacher(body = body) }
@@ -44,7 +44,7 @@ class AuthDataSourceImpl @Inject constructor(
         )
     }.flowOn(Dispatchers.IO)
 
-    override suspend fun signUpProfessor(body: SignUpProfessorRequest): Flow<Unit> = flow {
+    override fun signUpProfessor(body: SignUpProfessorRequest): Flow<Unit> = flow {
         emit(
             BitgoeulApiHandler<Unit>()
                 .httpRequest { authAPI.signUpProfessor(body = body) }
@@ -53,7 +53,7 @@ class AuthDataSourceImpl @Inject constructor(
     }.flowOn(Dispatchers.IO)
 
 
-    override suspend fun signUpGovernment(body: SignUpGovernmentRequest): Flow<Unit> = flow {
+    override fun signUpGovernment(body: SignUpGovernmentRequest): Flow<Unit> = flow {
         emit(
             BitgoeulApiHandler<Unit>()
                 .httpRequest { authAPI.signUpGovernment(body = body) }
@@ -61,7 +61,7 @@ class AuthDataSourceImpl @Inject constructor(
         )
     }.flowOn(Dispatchers.IO)
 
-    override suspend fun signUpCompanyInstructor(body: SignUpCompanyInstructorRequest): Flow<Unit> = flow {
+    override fun signUpCompanyInstructor(body: SignUpCompanyInstructorRequest): Flow<Unit> = flow {
         emit(
             BitgoeulApiHandler<Unit>()
                 .httpRequest { authAPI.signUpCompanyInstructor(body = body) }
@@ -69,7 +69,7 @@ class AuthDataSourceImpl @Inject constructor(
         )
     }.flowOn(Dispatchers.IO)
 
-    override suspend fun signUpBbozzakTeacher(body: SignUpBbozzakTeacherRequest): Flow<Unit> = flow {
+    override fun signUpBbozzakTeacher(body: SignUpBbozzakTeacherRequest): Flow<Unit> = flow {
         emit(
             BitgoeulApiHandler<Unit>()
                 .httpRequest { authAPI.signUpBbozzakTeacher(body = body) }
@@ -77,7 +77,7 @@ class AuthDataSourceImpl @Inject constructor(
         )
     }.flowOn(Dispatchers.IO)
 
-    override suspend fun findPassword(body: FindPasswordRequest): Flow<Unit> = flow {
+    override fun findPassword(body: FindPasswordRequest): Flow<Unit> = flow {
         emit(
             BitgoeulApiHandler<Unit>()
                 .httpRequest { authAPI.findPassword(body = body) }
@@ -85,7 +85,7 @@ class AuthDataSourceImpl @Inject constructor(
         )
     }.flowOn(Dispatchers.IO)
 
-    override suspend fun logout(): Flow<Unit> = flow {
+    override fun logout(): Flow<Unit> = flow {
         emit(
             BitgoeulApiHandler<Unit>()
                 .httpRequest { authAPI.logout() }
@@ -93,7 +93,7 @@ class AuthDataSourceImpl @Inject constructor(
         )
     }.flowOn(Dispatchers.IO)
 
-    override suspend fun withdraw(): Flow<Unit> = flow {
+    override fun withdraw(): Flow<Unit> = flow {
         emit(
             BitgoeulApiHandler<Unit>()
                 .httpRequest { authAPI.withdraw() }

--- a/core/network/src/main/java/com/msg/network/datasource/certification/CertificationDataSource.kt
+++ b/core/network/src/main/java/com/msg/network/datasource/certification/CertificationDataSource.kt
@@ -6,8 +6,8 @@ import kotlinx.coroutines.flow.Flow
 import java.util.UUID
 
 interface CertificationDataSource {
-    suspend fun getCertificationListForTeacher(studentId: UUID): Flow<List<CertificationListResponse>>
-    suspend fun getCertificationListForStudent(): Flow<List<CertificationListResponse>>
-    suspend fun writeCertification(body: WriteCertificationRequest): Flow<Unit>
-    suspend fun editCertification(id: UUID, body: WriteCertificationRequest): Flow<Unit>
+    fun getCertificationListForTeacher(studentId: UUID): Flow<List<CertificationListResponse>>
+    fun getCertificationListForStudent(): Flow<List<CertificationListResponse>>
+    fun writeCertification(body: WriteCertificationRequest): Flow<Unit>
+    fun editCertification(id: UUID, body: WriteCertificationRequest): Flow<Unit>
 }

--- a/core/network/src/main/java/com/msg/network/datasource/certification/CertificationDataSourceImpl.kt
+++ b/core/network/src/main/java/com/msg/network/datasource/certification/CertificationDataSourceImpl.kt
@@ -14,7 +14,7 @@ import javax.inject.Inject
 class CertificationDataSourceImpl @Inject constructor(
     private val certificationAPI: CertificationAPI,
 ) : CertificationDataSource {
-    override suspend fun getCertificationListForTeacher(studentId: UUID): Flow<List<CertificationListResponse>> =
+    override fun getCertificationListForTeacher(studentId: UUID): Flow<List<CertificationListResponse>> =
         flow {
             emit(
                 BitgoeulApiHandler<List<CertificationListResponse>>()
@@ -23,7 +23,7 @@ class CertificationDataSourceImpl @Inject constructor(
             )
         }
 
-    override suspend fun getCertificationListForStudent(): Flow<List<CertificationListResponse>> =
+    override fun getCertificationListForStudent(): Flow<List<CertificationListResponse>> =
         flow {
             emit(
                 BitgoeulApiHandler<List<CertificationListResponse>>()
@@ -32,7 +32,7 @@ class CertificationDataSourceImpl @Inject constructor(
             )
         }
 
-    override suspend fun writeCertification(body: WriteCertificationRequest): Flow<Unit> = flow {
+    override fun writeCertification(body: WriteCertificationRequest): Flow<Unit> = flow {
         emit(
             BitgoeulApiHandler<Unit>()
                 .httpRequest { certificationAPI.writeCertification(body = body) }
@@ -40,7 +40,7 @@ class CertificationDataSourceImpl @Inject constructor(
         )
     }.flowOn(Dispatchers.IO)
 
-    override suspend fun editCertification(
+    override fun editCertification(
         id: UUID,
         body: WriteCertificationRequest,
     ): Flow<Unit> = flow {

--- a/core/network/src/main/java/com/msg/network/datasource/club/ClubDataSource.kt
+++ b/core/network/src/main/java/com/msg/network/datasource/club/ClubDataSource.kt
@@ -8,8 +8,8 @@ import kotlinx.coroutines.flow.Flow
 import java.util.UUID
 
 interface ClubDataSource {
-    suspend fun getClubList(highSchool: HighSchool): Flow<List<ClubListResponse>>
-    suspend fun getClubDetail(id: Long): Flow<ClubDetailResponse>
-    suspend fun getStudentBelongClubDetail(id:Long, studentId: UUID): Flow<StudentBelongClubResponse>
-    suspend fun getMyClubDetail(): Flow<ClubDetailResponse>
+    fun getClubList(highSchool: HighSchool): Flow<List<ClubListResponse>>
+    fun getClubDetail(id: Long): Flow<ClubDetailResponse>
+    fun getStudentBelongClubDetail(id:Long, studentId: UUID): Flow<StudentBelongClubResponse>
+    fun getMyClubDetail(): Flow<ClubDetailResponse>
 }

--- a/core/network/src/main/java/com/msg/network/datasource/club/ClubDataSourceImpl.kt
+++ b/core/network/src/main/java/com/msg/network/datasource/club/ClubDataSourceImpl.kt
@@ -14,7 +14,7 @@ import javax.inject.Inject
 class ClubDataSourceImpl @Inject constructor(
     private val clubAPI: ClubAPI,
 ) : ClubDataSource {
-    override suspend fun getClubList(highSchool: HighSchool): Flow<List<ClubListResponse>> = flow {
+    override fun getClubList(highSchool: HighSchool): Flow<List<ClubListResponse>> = flow {
         emit(
             BitgoeulApiHandler<List<ClubListResponse>>()
                 .httpRequest { clubAPI.getClubList(highSchool = highSchool) }
@@ -22,7 +22,7 @@ class ClubDataSourceImpl @Inject constructor(
         )
     }
 
-    override suspend fun getClubDetail(id: Long): Flow<ClubDetailResponse> = flow {
+    override fun getClubDetail(id: Long): Flow<ClubDetailResponse> = flow {
         emit(
             BitgoeulApiHandler<ClubDetailResponse>()
                 .httpRequest { clubAPI.getClubDetail(id = id) }
@@ -30,7 +30,7 @@ class ClubDataSourceImpl @Inject constructor(
         )
     }
 
-    override suspend fun getStudentBelongClubDetail(id: Long, studentId: UUID): Flow<StudentBelongClubResponse> = flow {
+    override fun getStudentBelongClubDetail(id: Long, studentId: UUID): Flow<StudentBelongClubResponse> = flow {
         emit(
             BitgoeulApiHandler<StudentBelongClubResponse>()
                 .httpRequest { clubAPI.getStudentBelongClubDetail(id = id, studentId = studentId) }
@@ -38,7 +38,7 @@ class ClubDataSourceImpl @Inject constructor(
         )
     }
 
-    override suspend fun getMyClubDetail(): Flow<ClubDetailResponse> = flow {
+    override fun getMyClubDetail(): Flow<ClubDetailResponse> = flow {
         emit(
             BitgoeulApiHandler<ClubDetailResponse>()
                 .httpRequest { clubAPI.getMyClubDetail() }

--- a/core/network/src/main/java/com/msg/network/datasource/email/EmailDataSource.kt
+++ b/core/network/src/main/java/com/msg/network/datasource/email/EmailDataSource.kt
@@ -5,6 +5,6 @@ import com.msg.model.remote.response.email.GetEmailAuthenticateStatusResponse
 import kotlinx.coroutines.flow.Flow
 
 interface EmailDataSource {
-    suspend fun sendLinkToEmail(body: SendLinkToEmailRequest): Flow<Unit>
-    suspend fun getEmailAuthenticateStatus(email: String): Flow<GetEmailAuthenticateStatusResponse>
+    fun sendLinkToEmail(body: SendLinkToEmailRequest): Flow<Unit>
+    fun getEmailAuthenticateStatus(email: String): Flow<GetEmailAuthenticateStatusResponse>
 }

--- a/core/network/src/main/java/com/msg/network/datasource/email/EmailDataSourceImpl.kt
+++ b/core/network/src/main/java/com/msg/network/datasource/email/EmailDataSourceImpl.kt
@@ -13,7 +13,7 @@ import javax.inject.Inject
 class EmailDataSourceImpl @Inject constructor(
     private val emailAPI: EmailAPI
 ) : EmailDataSource {
-    override suspend fun sendLinkToEmail(body: SendLinkToEmailRequest): Flow<Unit> = flow {
+    override fun sendLinkToEmail(body: SendLinkToEmailRequest): Flow<Unit> = flow {
         emit(
             BitgoeulApiHandler<Unit>()
                 .httpRequest { emailAPI.sendLinkToEmail(body = body) }
@@ -21,7 +21,7 @@ class EmailDataSourceImpl @Inject constructor(
         )
     }.flowOn(Dispatchers.IO)
 
-    override suspend fun getEmailAuthenticateStatus(email: String): Flow<GetEmailAuthenticateStatusResponse> = flow {
+    override fun getEmailAuthenticateStatus(email: String): Flow<GetEmailAuthenticateStatusResponse> = flow {
         emit(
             BitgoeulApiHandler<GetEmailAuthenticateStatusResponse>()
                 .httpRequest { emailAPI.getEmailAuthenticateStatus(email = email) }

--- a/core/network/src/main/java/com/msg/network/datasource/faq/FaqDataSource.kt
+++ b/core/network/src/main/java/com/msg/network/datasource/faq/FaqDataSource.kt
@@ -5,6 +5,6 @@ import com.msg.model.remote.response.faq.GetFrequentlyAskedQuestionDetailRespons
 import kotlinx.coroutines.flow.Flow
 
 interface FaqDataSource {
-    suspend fun addFrequentlyAskedQuestions(body: AddFrequentlyAskedQuestionsRequest): Flow<Unit>
-    suspend fun getFrequentlyAskedQuestionsList(): Flow<List<GetFrequentlyAskedQuestionDetailResponse>>
+    fun addFrequentlyAskedQuestions(body: AddFrequentlyAskedQuestionsRequest): Flow<Unit>
+    fun getFrequentlyAskedQuestionsList(): Flow<List<GetFrequentlyAskedQuestionDetailResponse>>
 }

--- a/core/network/src/main/java/com/msg/network/datasource/faq/FaqDataSourceImpl.kt
+++ b/core/network/src/main/java/com/msg/network/datasource/faq/FaqDataSourceImpl.kt
@@ -13,7 +13,7 @@ import javax.inject.Inject
 class FaqDataSourceImpl @Inject constructor(
     private val faqAPI: FaqAPI,
 ) : FaqDataSource {
-    override suspend fun addFrequentlyAskedQuestions(body: AddFrequentlyAskedQuestionsRequest): Flow<Unit> =
+    override fun addFrequentlyAskedQuestions(body: AddFrequentlyAskedQuestionsRequest): Flow<Unit> =
         flow {
             emit(
                 BitgoeulApiHandler<Unit>()
@@ -22,7 +22,7 @@ class FaqDataSourceImpl @Inject constructor(
             )
         }.flowOn(Dispatchers.IO)
 
-    override suspend fun getFrequentlyAskedQuestionsList(): Flow<List<GetFrequentlyAskedQuestionDetailResponse>> =
+    override fun getFrequentlyAskedQuestionsList(): Flow<List<GetFrequentlyAskedQuestionDetailResponse>> =
         flow {
             emit(
                 BitgoeulApiHandler<List<GetFrequentlyAskedQuestionDetailResponse>>()

--- a/core/network/src/main/java/com/msg/network/datasource/lecture/LectureDataSource.kt
+++ b/core/network/src/main/java/com/msg/network/datasource/lecture/LectureDataSource.kt
@@ -14,17 +14,17 @@ import kotlinx.coroutines.flow.Flow
 import java.util.UUID
 
 interface LectureDataSource {
-    suspend fun openLecture(body: OpenLectureRequest): Flow<Unit>
-    suspend fun getLectureList(page: Int, size: Int, type: String?): Flow<LectureListResponse>
-    suspend fun getDetailLecture(id: UUID): Flow<DetailLectureResponse>
-    suspend fun lectureApplication(id: UUID): Flow<Unit>
-    suspend fun lectureApplicationCancel(id: UUID): Flow<Unit>
-    suspend fun searchProfessor(keyword: String): Flow<SearchProfessorResponse>
-    suspend fun searchLine(keyword: String, division: String): Flow<SearchLineResponse>
-    suspend fun searchDepartment(keyword: String): Flow<SearchDepartmentResponse>
-    suspend fun searchDivision(keyword: String): Flow<SearchDivisionResponse>
-    suspend fun getLectureSignUpHistory(studentId: UUID): Flow<GetLectureSignUpHistoryResponse>
-    suspend fun getTakingLectureStudentList(id: UUID): Flow<GetTakingLectureStudentListResponse>
-    suspend fun editLectureCourseCompletionStatus(id: UUID, studentId: UUID, isComplete: Boolean): Flow<Unit>
-    suspend fun downloadExcelFile(): Flow<DownloadExcelFileResponse>
+    fun openLecture(body: OpenLectureRequest): Flow<Unit>
+    fun getLectureList(page: Int, size: Int, type: String?): Flow<LectureListResponse>
+    fun getDetailLecture(id: UUID): Flow<DetailLectureResponse>
+    fun lectureApplication(id: UUID): Flow<Unit>
+    fun lectureApplicationCancel(id: UUID): Flow<Unit>
+    fun searchProfessor(keyword: String): Flow<SearchProfessorResponse>
+    fun searchLine(keyword: String, division: String): Flow<SearchLineResponse>
+    fun searchDepartment(keyword: String): Flow<SearchDepartmentResponse>
+    fun searchDivision(keyword: String): Flow<SearchDivisionResponse>
+    fun getLectureSignUpHistory(studentId: UUID): Flow<GetLectureSignUpHistoryResponse>
+    fun getTakingLectureStudentList(id: UUID): Flow<GetTakingLectureStudentListResponse>
+    fun editLectureCourseCompletionStatus(id: UUID, studentId: UUID, isComplete: Boolean): Flow<Unit>
+    fun downloadExcelFile(): Flow<DownloadExcelFileResponse>
 }

--- a/core/network/src/main/java/com/msg/network/datasource/lecture/LectureDataSourceImpl.kt
+++ b/core/network/src/main/java/com/msg/network/datasource/lecture/LectureDataSourceImpl.kt
@@ -22,7 +22,7 @@ import javax.inject.Inject
 class LectureDataSourceImpl @Inject constructor(
     private val lectureAPI: LectureAPI,
 ) : LectureDataSource {
-    override suspend fun openLecture(body: OpenLectureRequest): Flow<Unit> = flow {
+    override fun openLecture(body: OpenLectureRequest): Flow<Unit> = flow {
         emit(
             BitgoeulApiHandler<Unit>()
                 .httpRequest { lectureAPI.openLecture(body = body) }
@@ -30,7 +30,7 @@ class LectureDataSourceImpl @Inject constructor(
         )
     }.flowOn(Dispatchers.IO)
 
-    override suspend fun getLectureList(
+    override fun getLectureList(
         page: Int,
         size: Int,
         type: String?,
@@ -48,7 +48,7 @@ class LectureDataSourceImpl @Inject constructor(
         )
     }.flowOn(Dispatchers.IO)
 
-    override suspend fun getDetailLecture(id: UUID): Flow<DetailLectureResponse> = flow {
+    override fun getDetailLecture(id: UUID): Flow<DetailLectureResponse> = flow {
         emit(
             BitgoeulApiHandler<DetailLectureResponse>()
                 .httpRequest { lectureAPI.getDetailLecture(id = id) }
@@ -56,7 +56,7 @@ class LectureDataSourceImpl @Inject constructor(
         )
     }.flowOn(Dispatchers.IO)
 
-    override suspend fun lectureApplication(id: UUID): Flow<Unit> = flow {
+    override fun lectureApplication(id: UUID): Flow<Unit> = flow {
         emit(
             BitgoeulApiHandler<Unit>()
                 .httpRequest { lectureAPI.lectureApplication(id = id) }
@@ -64,7 +64,7 @@ class LectureDataSourceImpl @Inject constructor(
         )
     }.flowOn(Dispatchers.IO)
 
-    override suspend fun lectureApplicationCancel(id: UUID): Flow<Unit> = flow {
+    override fun lectureApplicationCancel(id: UUID): Flow<Unit> = flow {
         emit(
             BitgoeulApiHandler<Unit>()
                 .httpRequest { lectureAPI.lectureApplicationCancel(id = id) }
@@ -72,7 +72,7 @@ class LectureDataSourceImpl @Inject constructor(
         )
     }.flowOn(Dispatchers.IO)
 
-    override suspend fun searchProfessor(keyword: String): Flow<SearchProfessorResponse> =
+    override fun searchProfessor(keyword: String): Flow<SearchProfessorResponse> =
         flow {
             emit(
                 BitgoeulApiHandler<SearchProfessorResponse>()
@@ -81,7 +81,7 @@ class LectureDataSourceImpl @Inject constructor(
             )
         }.flowOn(Dispatchers.IO)
 
-    override suspend fun searchLine(keyword: String, division: String): Flow<SearchLineResponse> =
+    override fun searchLine(keyword: String, division: String): Flow<SearchLineResponse> =
         flow {
             emit(
                 BitgoeulApiHandler<SearchLineResponse>()
@@ -90,7 +90,7 @@ class LectureDataSourceImpl @Inject constructor(
             )
         }.flowOn(Dispatchers.IO)
 
-    override suspend fun searchDepartment(keyword: String): Flow<SearchDepartmentResponse> = flow {
+    override fun searchDepartment(keyword: String): Flow<SearchDepartmentResponse> = flow {
         emit(
             BitgoeulApiHandler<SearchDepartmentResponse>()
                 .httpRequest { lectureAPI.searchDepartment(keyword = keyword) }
@@ -98,7 +98,7 @@ class LectureDataSourceImpl @Inject constructor(
         )
     }.flowOn(Dispatchers.IO)
 
-    override suspend fun searchDivision(keyword: String): Flow<SearchDivisionResponse> = flow {
+    override fun searchDivision(keyword: String): Flow<SearchDivisionResponse> = flow {
         emit(
             BitgoeulApiHandler<SearchDivisionResponse>()
                 .httpRequest { lectureAPI.searchDivision(keyword = keyword) }
@@ -106,7 +106,7 @@ class LectureDataSourceImpl @Inject constructor(
         )
     }.flowOn(Dispatchers.IO)
 
-    override suspend fun getLectureSignUpHistory(studentId: UUID): Flow<GetLectureSignUpHistoryResponse> =
+    override fun getLectureSignUpHistory(studentId: UUID): Flow<GetLectureSignUpHistoryResponse> =
         flow {
             emit(
                 BitgoeulApiHandler<GetLectureSignUpHistoryResponse>()
@@ -115,7 +115,7 @@ class LectureDataSourceImpl @Inject constructor(
             )
         }.flowOn(Dispatchers.IO)
 
-    override suspend fun getTakingLectureStudentList(id: UUID): Flow<GetTakingLectureStudentListResponse> =
+    override fun getTakingLectureStudentList(id: UUID): Flow<GetTakingLectureStudentListResponse> =
         flow {
             emit(
                 BitgoeulApiHandler<GetTakingLectureStudentListResponse>()
@@ -124,7 +124,7 @@ class LectureDataSourceImpl @Inject constructor(
             )
         }.flowOn(Dispatchers.IO)
 
-    override suspend fun editLectureCourseCompletionStatus(id: UUID, studentId: UUID, isComplete: Boolean): Flow<Unit> =
+    override fun editLectureCourseCompletionStatus(id: UUID, studentId: UUID, isComplete: Boolean): Flow<Unit> =
         flow {
             emit(
                 BitgoeulApiHandler<Unit>()
@@ -139,7 +139,7 @@ class LectureDataSourceImpl @Inject constructor(
             )
         }.flowOn(Dispatchers.IO)
 
-    override suspend fun downloadExcelFile(): Flow<DownloadExcelFileResponse> = flow {
+    override fun downloadExcelFile(): Flow<DownloadExcelFileResponse> = flow {
         emit(
             BitgoeulApiHandler<DownloadExcelFileResponse>()
                 .httpRequest {

--- a/core/network/src/main/java/com/msg/network/datasource/post/PostDataSource.kt
+++ b/core/network/src/main/java/com/msg/network/datasource/post/PostDataSource.kt
@@ -8,9 +8,9 @@ import kotlinx.coroutines.flow.Flow
 import java.util.UUID
 
 interface PostDataSource {
-    suspend fun sendPost(body: WritePostRequest): Flow<Unit>
-    suspend fun getPostList(type: FeedType, size: Int, page: Int): Flow<GetPostListResponse>
-    suspend fun getDetailPost(id: UUID): Flow<GetDetailPostResponse>
-    suspend fun editPost(id: UUID, body: WritePostRequest): Flow<Unit>
-    suspend fun deletePost(id: UUID): Flow<Unit>
+    fun sendPost(body: WritePostRequest): Flow<Unit>
+    fun getPostList(type: FeedType, size: Int, page: Int): Flow<GetPostListResponse>
+    fun getDetailPost(id: UUID): Flow<GetDetailPostResponse>
+    fun editPost(id: UUID, body: WritePostRequest): Flow<Unit>
+    fun deletePost(id: UUID): Flow<Unit>
 }

--- a/core/network/src/main/java/com/msg/network/datasource/post/PostDataSourceImpl.kt
+++ b/core/network/src/main/java/com/msg/network/datasource/post/PostDataSourceImpl.kt
@@ -16,7 +16,7 @@ import javax.inject.Inject
 class PostDataSourceImpl @Inject constructor(
     private val postAPI: PostAPI
 ) : PostDataSource {
-    override suspend fun sendPost(body: WritePostRequest): Flow<Unit> = flow {
+    override fun sendPost(body: WritePostRequest): Flow<Unit> = flow {
         emit(
             BitgoeulApiHandler<Unit>()
                 .httpRequest { postAPI.sendPost(body = body) }
@@ -24,7 +24,7 @@ class PostDataSourceImpl @Inject constructor(
         )
     }.flowOn(Dispatchers.IO)
 
-    override suspend fun getPostList(type: FeedType, size: Int, page: Int): Flow<GetPostListResponse> = flow {
+    override fun getPostList(type: FeedType, size: Int, page: Int): Flow<GetPostListResponse> = flow {
         emit(
             BitgoeulApiHandler<GetPostListResponse>()
                 .httpRequest {
@@ -38,7 +38,7 @@ class PostDataSourceImpl @Inject constructor(
         )
     }.flowOn(Dispatchers.IO)
 
-    override suspend fun getDetailPost(id: UUID): Flow<GetDetailPostResponse> = flow {
+    override fun getDetailPost(id: UUID): Flow<GetDetailPostResponse> = flow {
         emit(
             BitgoeulApiHandler<GetDetailPostResponse>()
                 .httpRequest { postAPI.getDetailPost(id = id) }
@@ -46,7 +46,7 @@ class PostDataSourceImpl @Inject constructor(
         )
     }.flowOn(Dispatchers.IO)
 
-    override suspend fun editPost(id: UUID, body: WritePostRequest): Flow<Unit> = flow {
+    override fun editPost(id: UUID, body: WritePostRequest): Flow<Unit> = flow {
         emit(
             BitgoeulApiHandler<Unit>()
                 .httpRequest {
@@ -59,7 +59,7 @@ class PostDataSourceImpl @Inject constructor(
         )
     }.flowOn(Dispatchers.IO)
 
-    override suspend fun deletePost(id: UUID): Flow<Unit> = flow {
+    override fun deletePost(id: UUID): Flow<Unit> = flow {
         emit(
             BitgoeulApiHandler<Unit>()
                 .httpRequest { postAPI.deletePost(id = id) }

--- a/core/network/src/main/java/com/msg/network/datasource/user/UserDataSource.kt
+++ b/core/network/src/main/java/com/msg/network/datasource/user/UserDataSource.kt
@@ -5,6 +5,6 @@ import com.msg.model.remote.response.user.InquiryMyPageResponse
 import kotlinx.coroutines.flow.Flow
 
 interface UserDataSource {
-    suspend fun changePassword(body: ChangePasswordRequest): Flow<Unit>
-    suspend fun inquiryMyPage(): Flow<InquiryMyPageResponse>
+    fun changePassword(body: ChangePasswordRequest): Flow<Unit>
+    fun inquiryMyPage(): Flow<InquiryMyPageResponse>
 }

--- a/core/network/src/main/java/com/msg/network/datasource/user/UserDataSourceImpl.kt
+++ b/core/network/src/main/java/com/msg/network/datasource/user/UserDataSourceImpl.kt
@@ -13,7 +13,7 @@ import javax.inject.Inject
 class UserDataSourceImpl @Inject constructor(
     private val userAPI: UserAPI
 ) : UserDataSource {
-    override suspend fun changePassword(body: ChangePasswordRequest): Flow<Unit> = flow {
+    override fun changePassword(body: ChangePasswordRequest): Flow<Unit> = flow {
         emit(
             BitgoeulApiHandler<Unit>()
                 .httpRequest { userAPI.changePassword(body = body) }
@@ -21,7 +21,7 @@ class UserDataSourceImpl @Inject constructor(
         )
     }.flowOn(Dispatchers.IO)
 
-    override suspend fun inquiryMyPage(): Flow<InquiryMyPageResponse> = flow {
+    override fun inquiryMyPage(): Flow<InquiryMyPageResponse> = flow {
         emit(
             BitgoeulApiHandler<InquiryMyPageResponse>()
                 .httpRequest { userAPI.inquiryMyPage() }

--- a/core/network/src/main/java/com/msg/network/util/AuthInterceptor.kt
+++ b/core/network/src/main/java/com/msg/network/util/AuthInterceptor.kt
@@ -64,10 +64,10 @@ class AuthInterceptor @Inject constructor(
                     val response = client.newCall(refreshRequest).execute()
                     if (response.isSuccessful) {
                         val token = jsonParser.parse(response.body!!.string()) as JsonObject
-                        dataSource.setAccessToken(token["accessToken"].toString())
-                        dataSource.setAccessTokenExp(token["accessExpiration"].toString())
-                        dataSource.setRefreshToken(token["refreshToken"].toString())
-                        dataSource.setRefreshTokenExp(token["refreshExpiration"].toString())
+                        dataSource.setAccessToken(token["accessToken"].toString()).first()
+                        dataSource.setAccessTokenExp(token["accessExpiration"].toString()).first()
+                        dataSource.setRefreshToken(token["refreshToken"].toString()).first()
+                        dataSource.setRefreshTokenExp(token["refreshExpiration"].toString()).first()
                     } else throw NeedLoginException()
                 }
             }


### PR DESCRIPTION
## 💡 개요
비동기 함수에 suspend와 Flow키워드가 혼용되어 있습니다.
## 📃 작업내용
비동기 함수에 suspend와 Flow키워드중 Flow만 적용하였습니다.
## 🔀 변경사항
DataSource들의 suspend fun이 Flow단일화 되었습니다.
Repository의 suspend fun이 Flow단일화 되었습니다.
AuthTokenDataSource의 Token set함수들의 suspend에서 Flow로 변경됨에 따라 로직이 변경되었습니다.
## 🙋‍♂️ 질문사항
제가 잘못 구현한 부분이 있거나 컨벤션에 맞지 않는 부분, 오타, 불필요한 공백이 있다면 알려주세요.