### PR TITLE
🔀 :: (#204) AuthTokenDataSource의 함수 수정

### DIFF
--- a/core/data/src/main/java/com/msg/data/repository/auth/AuthRepositoryImpl.kt
+++ b/core/data/src/main/java/com/msg/data/repository/auth/AuthRepositoryImpl.kt
@@ -11,7 +11,6 @@ import com.msg.model.remote.request.auth.SignUpJobClubTeacherRequest
 import com.msg.model.remote.request.auth.SignUpProfessorRequest
 import com.msg.model.remote.request.auth.SignUpStudentRequest
 import com.msg.network.datasource.auth.AuthDataSource
-import kotlinx.coroutines.coroutineScope
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.first
 import kotlinx.coroutines.flow.flow

--- a/core/datastore/src/main/java/com/msg/datastore/AuthTokenDataSource.kt
+++ b/core/datastore/src/main/java/com/msg/datastore/AuthTokenDataSource.kt
@@ -27,25 +27,17 @@ class AuthTokenDataSource @Inject constructor(
             }
         }
 
-
-    fun setAccessTokenExp(accessTokenExp: String): Flow<Unit> = flow {
-        authToken.updateData {
-            it.toBuilder()
-                .setAccessExp(accessTokenExp)
-                .build()
-        }
-        emit(Unit)
-    }
-
-    fun getRefreshToken(): Flow<String> = authToken.data.map {
-        it.refreshToken ?: ""
+    fun setAccessTokenExp(accessTokenExp: String): Flow<Unit> {
+        return updateAuthToken { it.toBuilder().setAccessExp(accessTokenExp).build() }
     }
 
     fun getRefreshToken(): Flow<String> = authToken.data
         .transform { data ->
             emit(data.refreshToken ?: "")
         }
-        emit(Unit)
+
+    fun setRefreshToken(refreshToken: String): Flow<Unit> {
+        return updateAuthToken { it.toBuilder().setRefreshToken(refreshToken).build() }
     }
 
     fun getRefreshTokenExp(): Flow<LocalDateTime> = authToken.data
@@ -54,6 +46,9 @@ class AuthTokenDataSource @Inject constructor(
                 emit(LocalDateTime.parse(it))
             }
         }
+
+    fun setRefreshTokenExp(refreshTokenExp: String): Flow<Unit> {
+        return updateAuthToken { it.toBuilder().setRefreshExp(refreshTokenExp).build() }
     }
 
     fun getAuthority(): Flow<Authority> = authToken.data
@@ -64,15 +59,13 @@ class AuthTokenDataSource @Inject constructor(
                 }
             }
         }
+
+    fun setAuthority(authority: Authority): Flow<Unit> {
+        return updateAuthToken { it.toBuilder().setAuthority(authority.name).build() }
     }
 
-
-    fun setAuthority(authority: Authority): Flow<Unit> = flow {
-        authToken.updateData {
-            it.toBuilder()
-                .setAuthority(authority.toString())
-                .build()
-        }
+    private fun updateAuthToken(update: (AuthToken) -> AuthToken): Flow<Unit> = flow {
+        authToken.updateData { update(it) }
         emit(Unit)
     }
 }

--- a/core/network/src/main/java/com/msg/network/util/AuthInterceptor.kt
+++ b/core/network/src/main/java/com/msg/network/util/AuthInterceptor.kt
@@ -12,7 +12,6 @@ import okhttp3.OkHttpClient
 import okhttp3.Request
 import okhttp3.RequestBody
 import okhttp3.Response
-import java.time.LocalDateTime
 import javax.inject.Inject
 
 class AuthInterceptor @Inject constructor(
@@ -35,8 +34,10 @@ class AuthInterceptor @Inject constructor(
 
 
         runBlocking {
-            val refreshTime = dataSource.getRefreshTokenExp().toString()
-            val accessTime = dataSource.getAccessTokenExp().toString()
+            val refreshTime = dataSource.getRefreshTokenExp().first()
+            val accessTime = dataSource.getAccessTokenExp().first()
+            val accessToken = dataSource.getAccessToken().first()
+            val refreshToken = dataSource.getRefreshToken().first()
 
             if (refreshTime == "") {
                 return@runBlocking

--- a/core/network/src/main/java/com/msg/network/util/AuthInterceptor.kt
+++ b/core/network/src/main/java/com/msg/network/util/AuthInterceptor.kt
@@ -39,7 +39,7 @@ class AuthInterceptor @Inject constructor(
             val accessToken = dataSource.getAccessToken().first()
             val refreshToken = dataSource.getRefreshToken().first()
 
-            if (refreshTime == "") {
+            if (refreshTime.toString() == "") {
                 return@runBlocking
             }
 

--- a/core/network/src/main/java/com/msg/network/util/AuthInterceptor.kt
+++ b/core/network/src/main/java/com/msg/network/util/AuthInterceptor.kt
@@ -75,7 +75,3 @@ class AuthInterceptor @Inject constructor(
         return chain.proceed(builder.build())
     }
 }
-
-fun LocalDateTime.isAfter(compare: LocalDateTime): Boolean {
-    return this > compare
-}

--- a/core/network/src/main/java/com/msg/network/util/DateTimeFormatter.kt
+++ b/core/network/src/main/java/com/msg/network/util/DateTimeFormatter.kt
@@ -1,15 +1,32 @@
 package com.msg.network.util
 
+import java.time.Instant
 import java.time.LocalDateTime
+import java.time.ZoneId
 import java.time.format.DateTimeFormatter
 import java.time.format.DateTimeParseException
 
 fun Any?.toLocalDateTime(): LocalDateTime? {
     val dateString = this?.toString()
-    if (dateString != null) {
-        return try {
-            LocalDateTime.parse(dateString, DateTimeFormatter.ofPattern("yyyy-MM-d'T'HH:mm:ss"))
+    return when {
+        dateString == null -> null
+        else -> try {
+            when {
+                dateString.matches(Regex("\\d{13}")) -> { // Milliseconds -> LocalDateTime 처리
+                    LocalDateTime.ofInstant(Instant.ofEpochMilli(dateString.toLong()), ZoneId.systemDefault())
+                }
+                dateString.contains('.') -> { // 나노초를 포함한 경우 나노초 제거
+                    val trimmedDateString = dateString.substring(0, dateString.indexOf('.'))
+                    LocalDateTime.parse(trimmedDateString, DateTimeFormatter.ofPattern("yyyy-MM-dd'T'HH:mm:ss"))
+                }
+                else -> { // 나노초를 포함하지 않은 경우
+                    LocalDateTime.parse(dateString, DateTimeFormatter.ofPattern("yyyy-MM-dd'T'HH:mm:ss"))
+                }
+            }
         } catch (e: DateTimeParseException) {
+            e.printStackTrace()
+            null
+        } catch (e: NumberFormatException) {
             e.printStackTrace()
             null
         }

--- a/core/network/src/main/java/com/msg/network/util/DateTimeFormatter.kt
+++ b/core/network/src/main/java/com/msg/network/util/DateTimeFormatter.kt
@@ -31,5 +31,4 @@ fun Any?.toLocalDateTime(): LocalDateTime? {
             null
         }
     }
-    return null
 }

--- a/feature/login/src/main/java/com/bitgoeul/login/viewmodel/AuthViewModel.kt
+++ b/feature/login/src/main/java/com/bitgoeul/login/viewmodel/AuthViewModel.kt
@@ -5,7 +5,6 @@ import androidx.lifecycle.viewModelScope
 import com.bitgoeul.login.viewmodel.util.Event
 import com.bitgoeul.login.viewmodel.util.errorHandling
 import com.msg.domain.auth.LoginUseCase
-import com.msg.domain.auth.LogoutUseCase
 import com.msg.domain.auth.SaveTokenUseCase
 import com.msg.model.remote.model.auth.AuthTokenModel
 import com.msg.model.remote.request.auth.LoginRequest
@@ -19,7 +18,6 @@ import javax.inject.Inject
 @HiltViewModel
 class AuthViewModel @Inject constructor(
     private val loginUseCase: LoginUseCase,
-    private val logoutUseCase: LogoutUseCase,
     private val saveTokenUseCase: SaveTokenUseCase,
 ) : ViewModel() {
     private val _saveTokenRequest = MutableStateFlow<Event<Nothing>>(Event.Loading)

--- a/feature/login/src/main/java/com/bitgoeul/login/viewmodel/AuthViewModel.kt
+++ b/feature/login/src/main/java/com/bitgoeul/login/viewmodel/AuthViewModel.kt
@@ -20,8 +20,8 @@ class AuthViewModel @Inject constructor(
     private val loginUseCase: LoginUseCase,
     private val saveTokenUseCase: SaveTokenUseCase,
 ) : ViewModel() {
-    private val _saveTokenRequest = MutableStateFlow<Event<Nothing>>(Event.Loading)
-    val saveTokenRequest = _saveTokenRequest.asStateFlow()
+    private val _saveTokenResponse = MutableStateFlow<Event<Nothing>>(Event.Loading)
+    val saveTokenRequest = _saveTokenResponse.asStateFlow()
 
     private val _loginResponse = MutableStateFlow<Event<AuthTokenModel>>(Event.Loading)
     val loginResponse = _loginResponse.asStateFlow()
@@ -47,9 +47,13 @@ class AuthViewModel @Inject constructor(
         saveTokenUseCase(
             data = data
         ).onSuccess {
-            _saveTokenRequest.value = Event.Success()
+            it.catch { remoteError ->
+                _saveTokenResponse.value = remoteError.errorHandling()
+            }.collect {
+                _saveTokenResponse.value = Event.Success()
+            }
         }.onFailure {
-            _saveTokenRequest.value = it.errorHandling()
+            _saveTokenResponse.value = it.errorHandling()
         }
     }
 }


### PR DESCRIPTION
## 💡 개요
AuthTokenDataSource의 함수 들의 공통로직과 다중 map사용부분 수정
## 📃 작업내용
AuthTokenDataSource의 함수 들의 공통로직을 함수화하여 처리하였고 다중 map사용부분을 transform을 적용해 수정했습니다.
서버에서 주는 LocalDateTime의 나노초를 처리하기위해 DateTimeFormmatter의 형식을 변경했습니다.
System.currentTimeMillis을 처리하기위해 DateTimeFormmatter의 형식을 변경했습니다.
## 🔀 변경사항
AuthTokenDataSource들의 get, set함수 로직
DateTimeFormmatter의 내부 처리 추가
## 🙋‍♂️ 질문사항
제가 잘못 구현한 부분이나 컨벤션에 맞지 않는 부분이 있다면 알려주세요.
