### PR TITLE
🔀 :: (#207) AuthTokenDataSource 분리

### DIFF
--- a/core/data/src/main/java/com/msg/data/repository/auth/AuthRepository.kt
+++ b/core/data/src/main/java/com/msg/data/repository/auth/AuthRepository.kt
@@ -1,5 +1,6 @@
 package com.msg.data.repository.auth
 
+import Authority
 import com.msg.model.remote.model.auth.AuthTokenModel
 import com.msg.model.remote.request.auth.FindPasswordRequest
 import com.msg.model.remote.request.auth.LoginRequest
@@ -13,7 +14,6 @@ import kotlinx.coroutines.flow.Flow
 
 interface AuthRepository {
     fun login(body: LoginRequest): Flow<AuthTokenModel>
-    fun saveToken(data: AuthTokenModel): Flow<Unit>
     fun signUpStudent(body: SignUpStudentRequest): Flow<Unit>
     fun signUpJobClubTeacher(body: SignUpJobClubTeacherRequest): Flow<Unit>
     fun signUpProfessor(body: SignUpProfessorRequest): Flow<Unit>
@@ -23,4 +23,7 @@ interface AuthRepository {
     fun findPassword(body: FindPasswordRequest): Flow<Unit>
     fun logout(): Flow<Unit>
     fun withdraw(): Flow<Unit>
+    fun saveToken(data: AuthTokenModel): Flow<Unit>
+    fun getAuthority(): Flow<Authority>
+
 }

--- a/core/data/src/main/java/com/msg/data/repository/auth/AuthRepositoryImpl.kt
+++ b/core/data/src/main/java/com/msg/data/repository/auth/AuthRepositoryImpl.kt
@@ -77,11 +77,13 @@ class AuthRepositoryImpl @Inject constructor(
     }
 
     override fun saveToken(data: AuthTokenModel): Flow<Unit> = flow {
-        localDataSource.setAccessToken(data.accessToken).first()
-        localDataSource.setAccessTokenExp(data.accessExpiredAt).first()
-        localDataSource.setRefreshToken(data.refreshToken).first()
-        localDataSource.setRefreshTokenExp(data.refreshExpiredAt).first()
-        localDataSource.setAuthority(data.authority).first()
+        with(localDataSource) {
+            setAccessToken(data.accessToken).first()
+            setAccessTokenExp(data.accessExpiredAt).first()
+            setRefreshToken(data.refreshToken).first()
+            setRefreshTokenExp(data.refreshExpiredAt).first()
+            setAuthority(data.authority).first()
+        }
     }
 
     override fun getAuthority(): Flow<Authority> {

--- a/core/data/src/main/java/com/msg/data/repository/auth/AuthRepositoryImpl.kt
+++ b/core/data/src/main/java/com/msg/data/repository/auth/AuthRepositoryImpl.kt
@@ -1,6 +1,6 @@
 package com.msg.data.repository.auth
 
-import com.msg.datastore.AuthTokenDataSource
+import com.msg.datastore.datasource.AuthTokenDataSource
 import com.msg.model.remote.model.auth.AuthTokenModel
 import com.msg.model.remote.request.auth.FindPasswordRequest
 import com.msg.model.remote.request.auth.LoginRequest

--- a/core/data/src/main/java/com/msg/data/repository/auth/AuthRepositoryImpl.kt
+++ b/core/data/src/main/java/com/msg/data/repository/auth/AuthRepositoryImpl.kt
@@ -1,5 +1,6 @@
 package com.msg.data.repository.auth
 
+import Authority
 import com.msg.datastore.datasource.AuthTokenDataSource
 import com.msg.model.remote.model.auth.AuthTokenModel
 import com.msg.model.remote.request.auth.FindPasswordRequest
@@ -17,69 +18,73 @@ import kotlinx.coroutines.flow.flow
 import javax.inject.Inject
 
 class AuthRepositoryImpl @Inject constructor(
-    private val authDataSource: AuthDataSource,
+    private val remoteDataSource: AuthDataSource,
     private val localDataSource: AuthTokenDataSource
 ) : AuthRepository {
     override fun login(body: LoginRequest): Flow<AuthTokenModel> {
-        return authDataSource.login(
+        return remoteDataSource.login(
             body = body
         )
     }
 
-    override fun saveToken(data: AuthTokenModel): Flow<Unit> = flow {
-            localDataSource.setAccessToken(data.accessToken).first()
-            localDataSource.setAccessTokenExp(data.accessExpiredAt).first()
-            localDataSource.setRefreshToken(data.refreshToken).first()
-            localDataSource.setRefreshTokenExp(data.refreshExpiredAt).first()
-            localDataSource.setAuthority(data.authority).first()
-    }
-
     override fun signUpStudent(body: SignUpStudentRequest): Flow<Unit> {
-        return authDataSource.signUpStudent(
+        return remoteDataSource.signUpStudent(
             body = body
         )
     }
 
     override fun signUpJobClubTeacher(body: SignUpJobClubTeacherRequest): Flow<Unit> {
-        return authDataSource.signUpJobClubTeacher(
+        return remoteDataSource.signUpJobClubTeacher(
             body = body
         )
     }
 
     override fun signUpProfessor(body: SignUpProfessorRequest): Flow<Unit> {
-        return authDataSource.signUpProfessor(
+        return remoteDataSource.signUpProfessor(
             body = body
         )
     }
 
     override fun signUpGovernment(body: SignUpGovernmentRequest): Flow<Unit> {
-        return authDataSource.signUpGovernment(
+        return remoteDataSource.signUpGovernment(
             body = body
         )
     }
 
     override fun signUpCompanyInstructor(body: SignUpCompanyInstructorRequest): Flow<Unit> {
-        return authDataSource.signUpCompanyInstructor(
+        return remoteDataSource.signUpCompanyInstructor(
             body = body
         )
     }
 
     override fun signUpBbozzakTeacher(body: SignUpBbozzakTeacherRequest): Flow<Unit> {
-        return authDataSource.signUpBbozzakTeacher(
+        return remoteDataSource.signUpBbozzakTeacher(
             body = body
         )
     }
 
     override fun findPassword(body: FindPasswordRequest): Flow<Unit> {
-        return authDataSource.findPassword(
+        return remoteDataSource.findPassword(
             body = body
         )
     }
     override fun logout(): Flow<Unit> {
-        return authDataSource.logout()
+        return remoteDataSource.logout()
     }
 
     override fun withdraw(): Flow<Unit> {
-        return authDataSource.withdraw()
+        return remoteDataSource.withdraw()
+    }
+
+    override fun saveToken(data: AuthTokenModel): Flow<Unit> = flow {
+        localDataSource.setAccessToken(data.accessToken).first()
+        localDataSource.setAccessTokenExp(data.accessExpiredAt).first()
+        localDataSource.setRefreshToken(data.refreshToken).first()
+        localDataSource.setRefreshTokenExp(data.refreshExpiredAt).first()
+        localDataSource.setAuthority(data.authority).first()
+    }
+
+    override fun getAuthority(): Flow<Authority> {
+        return localDataSource.getAuthority()
     }
 }

--- a/core/datastore/src/main/java/com/msg/datastore/datasource/AuthTokenDataSource.kt
+++ b/core/datastore/src/main/java/com/msg/datastore/datasource/AuthTokenDataSource.kt
@@ -1,0 +1,19 @@
+package com.msg.datastore.datasource
+
+import Authority
+import kotlinx.coroutines.flow.Flow
+import java.time.LocalDateTime
+
+
+interface AuthTokenDataSource {
+    fun getAccessToken(): Flow<String>
+    fun setAccessToken(accessToken: String): Flow<Unit>
+    fun getAccessTokenExp(): Flow<LocalDateTime>
+    fun setAccessTokenExp(accessTokenExp: String): Flow<Unit>
+    fun getRefreshToken(): Flow<String>
+    fun setRefreshToken(refreshToken: String): Flow<Unit>
+    fun getRefreshTokenExp(): Flow<LocalDateTime>
+    fun setRefreshTokenExp(refreshTokenExp: String): Flow<Unit>
+    fun getAuthority(): Flow<Authority>
+    fun setAuthority(authority: Authority): Flow<Unit>
+}

--- a/core/datastore/src/main/java/com/msg/datastore/datasource/AuthTokenDataSourceImpl.kt
+++ b/core/datastore/src/main/java/com/msg/datastore/datasource/AuthTokenDataSourceImpl.kt
@@ -1,57 +1,59 @@
-package com.msg.datastore
+package com.msg.datastore.datasource
 
 import Authority
 import androidx.datastore.core.DataStore
+import com.msg.datastore.AuthToken
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.flow
 import kotlinx.coroutines.flow.transform
 import java.time.LocalDateTime
 import javax.inject.Inject
 
-class AuthTokenDataSource @Inject constructor(
-    private val authToken: DataStore<AuthToken>,
-) {
-    fun getAccessToken(): Flow<String> = authToken.data
+class AuthTokenDataSourceImpl @Inject constructor(
+    private val authToken: DataStore<AuthToken>
+) : AuthTokenDataSource {
+
+    override fun getAccessToken(): Flow<String> = authToken.data
         .transform { data ->
             emit(data.accessToken ?: "")
         }
 
-    fun setAccessToken(accessToken: String): Flow<Unit>  {
+    override fun setAccessToken(accessToken: String): Flow<Unit> {
         return updateAuthToken { it.toBuilder().setAccessToken(accessToken).build() }
     }
 
-    fun getAccessTokenExp(): Flow<LocalDateTime> = authToken.data
+    override fun getAccessTokenExp(): Flow<LocalDateTime> = authToken.data
         .transform { data ->
             data.accessExp?.let {
                 emit(LocalDateTime.parse(it))
             }
         }
 
-    fun setAccessTokenExp(accessTokenExp: String): Flow<Unit> {
+    override fun setAccessTokenExp(accessTokenExp: String): Flow<Unit> {
         return updateAuthToken { it.toBuilder().setAccessExp(accessTokenExp).build() }
     }
 
-    fun getRefreshToken(): Flow<String> = authToken.data
+    override fun getRefreshToken(): Flow<String> = authToken.data
         .transform { data ->
             emit(data.refreshToken ?: "")
         }
 
-    fun setRefreshToken(refreshToken: String): Flow<Unit> {
+    override fun setRefreshToken(refreshToken: String): Flow<Unit> {
         return updateAuthToken { it.toBuilder().setRefreshToken(refreshToken).build() }
     }
 
-    fun getRefreshTokenExp(): Flow<LocalDateTime> = authToken.data
+    override fun getRefreshTokenExp(): Flow<LocalDateTime> = authToken.data
         .transform { data ->
             data.refreshExp?.let {
                 emit(LocalDateTime.parse(it))
             }
         }
 
-    fun setRefreshTokenExp(refreshTokenExp: String): Flow<Unit> {
+    override fun setRefreshTokenExp(refreshTokenExp: String): Flow<Unit> {
         return updateAuthToken { it.toBuilder().setRefreshExp(refreshTokenExp).build() }
     }
 
-    fun getAuthority(): Flow<Authority> = authToken.data
+    override fun getAuthority(): Flow<Authority> = authToken.data
         .transform { data ->
             data.authority?.let { authority ->
                 Authority.entries.firstOrNull { it.name == authority }?.let {
@@ -60,7 +62,7 @@ class AuthTokenDataSource @Inject constructor(
             }
         }
 
-    fun setAuthority(authority: Authority): Flow<Unit> {
+    override fun setAuthority(authority: Authority): Flow<Unit> {
         return updateAuthToken { it.toBuilder().setAuthority(authority.name).build() }
     }
 

--- a/core/datastore/src/main/java/com/msg/datastore/di/DataStoreModule.kt
+++ b/core/datastore/src/main/java/com/msg/datastore/di/DataStoreModule.kt
@@ -15,7 +15,7 @@ import javax.inject.Singleton
 
 @Module
 @InstallIn(SingletonComponent::class)
-object DataSourceModule {
+object DataStoreModule {
     @Provides
     @Singleton
     fun provideAuthTokenDataStore(

--- a/core/datastore/src/main/java/com/msg/datastore/di/LocalDataSourceModule.kt
+++ b/core/datastore/src/main/java/com/msg/datastore/di/LocalDataSourceModule.kt
@@ -1,0 +1,17 @@
+package com.msg.datastore.di
+
+import com.msg.datastore.datasource.AuthTokenDataSource
+import com.msg.datastore.datasource.AuthTokenDataSourceImpl
+import dagger.Binds
+import dagger.Module
+import dagger.hilt.InstallIn
+import dagger.hilt.components.SingletonComponent
+
+@Module
+@InstallIn(SingletonComponent::class)
+abstract class LocalDataSourceModule {
+    @Binds
+    abstract fun bindAuthTokenDataSource(
+        authTokenDataSourceImpl: AuthTokenDataSourceImpl
+    ): AuthTokenDataSource
+}

--- a/core/network/src/main/java/com/msg/network/di/DataSourceModule.kt
+++ b/core/network/src/main/java/com/msg/network/di/DataSourceModule.kt
@@ -1,5 +1,7 @@
 package com.msg.network.di
 
+import com.msg.datastore.datasource.AuthTokenDataSource
+import com.msg.datastore.datasource.AuthTokenDataSourceImpl
 import com.msg.network.datasource.activity.ActivityDataSource
 import com.msg.network.datasource.activity.ActivityDataSourceImpl
 import com.msg.network.datasource.admin.AdminDataSource
@@ -77,4 +79,9 @@ abstract class DataSourceModule {
     abstract fun bindEmailDataSource(
         emailDataSourceImpl: EmailDataSourceImpl
     ): EmailDataSource
+
+    @Binds
+    abstract fun bindAuthTokenDataSource(
+        authTokenDataSourceImpl: AuthTokenDataSourceImpl
+    ): AuthTokenDataSource
 }

--- a/core/network/src/main/java/com/msg/network/di/RemoteDataSourceModule.kt
+++ b/core/network/src/main/java/com/msg/network/di/RemoteDataSourceModule.kt
@@ -1,7 +1,5 @@
 package com.msg.network.di
 
-import com.msg.datastore.datasource.AuthTokenDataSource
-import com.msg.datastore.datasource.AuthTokenDataSourceImpl
 import com.msg.network.datasource.activity.ActivityDataSource
 import com.msg.network.datasource.activity.ActivityDataSourceImpl
 import com.msg.network.datasource.admin.AdminDataSource
@@ -29,7 +27,7 @@ import dagger.hilt.components.SingletonComponent
 
 @Module
 @InstallIn(SingletonComponent::class)
-abstract class DataSourceModule {
+abstract class RemoteDataSourceModule {
     @Binds
     abstract fun bindAuthDataSource(
         authDataSourceImpl: AuthDataSourceImpl
@@ -79,9 +77,4 @@ abstract class DataSourceModule {
     abstract fun bindEmailDataSource(
         emailDataSourceImpl: EmailDataSourceImpl
     ): EmailDataSource
-
-    @Binds
-    abstract fun bindAuthTokenDataSource(
-        authTokenDataSourceImpl: AuthTokenDataSourceImpl
-    ): AuthTokenDataSource
 }

--- a/core/network/src/main/java/com/msg/network/util/AuthInterceptor.kt
+++ b/core/network/src/main/java/com/msg/network/util/AuthInterceptor.kt
@@ -2,7 +2,7 @@ package com.msg.network.util
 
 import com.google.gson.JsonObject
 import com.google.gson.JsonParser
-import com.msg.datastore.AuthTokenDataSource
+import com.msg.datastore.datasource.AuthTokenDataSource
 import com.msg.network.BuildConfig
 import com.msg.network.exception.NeedLoginException
 import kotlinx.coroutines.flow.first

--- a/feature/certification/src/main/java/com/msg/certification/CertificationViewModel.kt
+++ b/feature/certification/src/main/java/com/msg/certification/CertificationViewModel.kt
@@ -8,7 +8,7 @@ import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
 import com.msg.certification.util.Event
 import com.msg.certification.util.errorHandling
-import com.msg.datastore.datasource.AuthTokenDataSource
+import com.msg.data.repository.auth.AuthRepository
 import com.msg.domain.certification.EditCertificationUseCase
 import com.msg.domain.certification.GetCertificationListForStudentUseCase
 import com.msg.domain.certification.GetCertificationListForTeacherUseCase
@@ -36,7 +36,7 @@ class CertificationViewModel @Inject constructor(
     private val editCertificationUseCase: EditCertificationUseCase,
     private val getStudentBelongClubUseCase: GetStudentBelongClubUseCase,
     private val getLectureSignUpHistoryUseCase: GetLectureSignUpHistoryUseCase,
-    private val authTokenDataSourceImpl: AuthTokenDataSource,
+    private val authRepository: AuthRepository,
     private val savedStateHandle: SavedStateHandle
 ) : ViewModel() {
 
@@ -54,10 +54,6 @@ class CertificationViewModel @Inject constructor(
 
     private val _getLectureSignUpHistoryResponse = MutableStateFlow<Event<GetLectureSignUpHistoryResponse>>(Event.Loading)
     val getLectureSignUpHistoryResponse = _getLectureSignUpHistoryResponse.asStateFlow()
-
-    private fun getRole(): Authority = runBlocking {
-        return@runBlocking authTokenDataSourceImpl.getAuthority().first()
-    }
 
     private val studentId = UUID.fromString(savedStateHandle.get<String>("studentId"))
 
@@ -190,5 +186,9 @@ class CertificationViewModel @Inject constructor(
                 _getLectureSignUpHistoryResponse.value = error.errorHandling()
             }
         }
+    }
+
+    private fun getRole(): Authority = runBlocking {
+        return@runBlocking authRepository.getAuthority().first()
     }
 }

--- a/feature/certification/src/main/java/com/msg/certification/CertificationViewModel.kt
+++ b/feature/certification/src/main/java/com/msg/certification/CertificationViewModel.kt
@@ -8,7 +8,7 @@ import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
 import com.msg.certification.util.Event
 import com.msg.certification.util.errorHandling
-import com.msg.datastore.AuthTokenDataSource
+import com.msg.datastore.datasource.AuthTokenDataSource
 import com.msg.domain.certification.EditCertificationUseCase
 import com.msg.domain.certification.GetCertificationListForStudentUseCase
 import com.msg.domain.certification.GetCertificationListForTeacherUseCase
@@ -36,7 +36,7 @@ class CertificationViewModel @Inject constructor(
     private val editCertificationUseCase: EditCertificationUseCase,
     private val getStudentBelongClubUseCase: GetStudentBelongClubUseCase,
     private val getLectureSignUpHistoryUseCase: GetLectureSignUpHistoryUseCase,
-    private val authTokenDataSource: AuthTokenDataSource,
+    private val authTokenDataSourceImpl: AuthTokenDataSource,
     private val savedStateHandle: SavedStateHandle
 ) : ViewModel() {
 
@@ -56,7 +56,7 @@ class CertificationViewModel @Inject constructor(
     val getLectureSignUpHistoryResponse = _getLectureSignUpHistoryResponse.asStateFlow()
 
     private fun getRole(): Authority = runBlocking {
-        return@runBlocking authTokenDataSource.getAuthority().first()
+        return@runBlocking authTokenDataSourceImpl.getAuthority().first()
     }
 
     private val studentId = UUID.fromString(savedStateHandle.get<String>("studentId"))

--- a/feature/club/src/main/java/com/msg/club/ClubViewModel.kt
+++ b/feature/club/src/main/java/com/msg/club/ClubViewModel.kt
@@ -8,7 +8,7 @@ import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
 import com.msg.club.util.Event
 import com.msg.club.util.errorHandling
-import com.msg.datastore.AuthTokenDataSource
+import com.msg.datastore.datasource.AuthTokenDataSource
 import com.msg.domain.club.GetClubDetailUseCase
 import com.msg.domain.club.GetClubListUseCase
 import com.msg.domain.club.GetMyClubDetailUseCase

--- a/feature/club/src/main/java/com/msg/club/ClubViewModel.kt
+++ b/feature/club/src/main/java/com/msg/club/ClubViewModel.kt
@@ -8,7 +8,7 @@ import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
 import com.msg.club.util.Event
 import com.msg.club.util.errorHandling
-import com.msg.datastore.datasource.AuthTokenDataSource
+import com.msg.data.repository.auth.AuthRepository
 import com.msg.domain.club.GetClubDetailUseCase
 import com.msg.domain.club.GetClubListUseCase
 import com.msg.domain.club.GetMyClubDetailUseCase
@@ -33,7 +33,7 @@ class ClubViewModel @Inject constructor(
     private val getClubListUseCase: GetClubListUseCase,
     private val getMyClubDetailUseCase: GetMyClubDetailUseCase,
     private val getStudentBelongClubUseCase: GetStudentBelongClubUseCase,
-    private val authTokenDataSource: AuthTokenDataSource,
+    private val authRepository: AuthRepository,
 ) : ViewModel() {
 
     private val _getClubDetailResponse = MutableStateFlow<Event<ClubDetailResponse>>(Event.Loading)
@@ -142,6 +142,6 @@ class ClubViewModel @Inject constructor(
 
 
     private fun getRole(): Authority = runBlocking {
-        return@runBlocking authTokenDataSource.getAuthority().first()
+        return@runBlocking authRepository.getAuthority().first()
     }
 }

--- a/feature/lecture/src/main/java/com/msg/lecture/viewmodel/LectureViewModel.kt
+++ b/feature/lecture/src/main/java/com/msg/lecture/viewmodel/LectureViewModel.kt
@@ -7,7 +7,7 @@ import androidx.compose.runtime.mutableStateListOf
 import androidx.compose.runtime.mutableStateOf
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
-import com.msg.datastore.datasource.AuthTokenDataSource
+import com.msg.data.repository.auth.AuthRepository
 import com.msg.domain.lecture.DownloadExcelFileUseCase
 import com.msg.domain.lecture.EditLectureCourseCompletionStatusUseCase
 import com.msg.domain.lecture.GetDetailLectureUseCase
@@ -61,7 +61,6 @@ class LectureViewModel @Inject constructor(
     private val getLectureListUseCase: GetLectureListUseCase,
     private val getDetailLectureUseCase: GetDetailLectureUseCase,
     private val openLectureUseCase: OpenLectureUseCase,
-    private val authTokenDataSourceImpl: AuthTokenDataSource,
     private val lectureApplicationUseCase: LectureApplicationUseCase,
     private val lectureApplicationCancelUseCase: LectureApplicationCancelUseCase,
     private val searchProfessorUseCase: SearchProfessorUseCase,
@@ -72,6 +71,7 @@ class LectureViewModel @Inject constructor(
     private val getTakingLectureStudentListUseCase: GetTakingLectureStudentListUseCase,
     private val editLectureCourseCompletionStatusUseCase: EditLectureCourseCompletionStatusUseCase,
     private val downloadExcelFileUseCase: DownloadExcelFileUseCase,
+    private val authRepository: AuthRepository,
 ) : ViewModel() {
 
     val role = getRole().toString()
@@ -584,6 +584,6 @@ class LectureViewModel @Inject constructor(
     }
 
     private fun getRole(): Authority = runBlocking {
-        return@runBlocking authTokenDataSourceImpl.getAuthority().first()
+        return@runBlocking authRepository.getAuthority().first()
     }
 }

--- a/feature/lecture/src/main/java/com/msg/lecture/viewmodel/LectureViewModel.kt
+++ b/feature/lecture/src/main/java/com/msg/lecture/viewmodel/LectureViewModel.kt
@@ -7,7 +7,7 @@ import androidx.compose.runtime.mutableStateListOf
 import androidx.compose.runtime.mutableStateOf
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
-import com.msg.datastore.AuthTokenDataSource
+import com.msg.datastore.datasource.AuthTokenDataSource
 import com.msg.domain.lecture.DownloadExcelFileUseCase
 import com.msg.domain.lecture.EditLectureCourseCompletionStatusUseCase
 import com.msg.domain.lecture.GetDetailLectureUseCase
@@ -61,7 +61,7 @@ class LectureViewModel @Inject constructor(
     private val getLectureListUseCase: GetLectureListUseCase,
     private val getDetailLectureUseCase: GetDetailLectureUseCase,
     private val openLectureUseCase: OpenLectureUseCase,
-    private val authTokenDataSource: AuthTokenDataSource,
+    private val authTokenDataSourceImpl: AuthTokenDataSource,
     private val lectureApplicationUseCase: LectureApplicationUseCase,
     private val lectureApplicationCancelUseCase: LectureApplicationCancelUseCase,
     private val searchProfessorUseCase: SearchProfessorUseCase,
@@ -584,6 +584,6 @@ class LectureViewModel @Inject constructor(
     }
 
     private fun getRole(): Authority = runBlocking {
-        return@runBlocking authTokenDataSource.getAuthority().first()
+        return@runBlocking authTokenDataSourceImpl.getAuthority().first()
     }
 }

--- a/feature/main/src/main/java/com/msg/main/FaqViewModel.kt
+++ b/feature/main/src/main/java/com/msg/main/FaqViewModel.kt
@@ -4,7 +4,7 @@ import Authority
 import androidx.compose.runtime.mutableStateListOf
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
-import com.msg.datastore.datasource.AuthTokenDataSource
+import com.msg.data.repository.auth.AuthRepository
 import com.msg.main.util.Event
 import com.msg.main.util.errorHandling
 import dagger.hilt.android.lifecycle.HiltViewModel
@@ -24,7 +24,7 @@ import com.msg.model.remote.response.faq.GetFrequentlyAskedQuestionDetailRespons
 class FaqViewModel @Inject constructor(
     private val addFAQUseCase: AddFAQUseCase,
     private val getFAQUseCase: GetFAQUseCase,
-    private val authTokenDataSourceImpl: AuthTokenDataSource
+    private val authRepository: AuthRepository,
 ) : ViewModel() {
 
     val role = getRole().toString()
@@ -76,6 +76,6 @@ class FaqViewModel @Inject constructor(
     }
 
     private fun getRole(): Authority = runBlocking {
-        return@runBlocking authTokenDataSourceImpl.getAuthority().first()
+        return@runBlocking authRepository.getAuthority().first()
     }
 }

--- a/feature/main/src/main/java/com/msg/main/FaqViewModel.kt
+++ b/feature/main/src/main/java/com/msg/main/FaqViewModel.kt
@@ -4,7 +4,7 @@ import Authority
 import androidx.compose.runtime.mutableStateListOf
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
-import com.msg.datastore.AuthTokenDataSource
+import com.msg.datastore.datasource.AuthTokenDataSource
 import com.msg.main.util.Event
 import com.msg.main.util.errorHandling
 import dagger.hilt.android.lifecycle.HiltViewModel
@@ -24,7 +24,7 @@ import com.msg.model.remote.response.faq.GetFrequentlyAskedQuestionDetailRespons
 class FaqViewModel @Inject constructor(
     private val addFAQUseCase: AddFAQUseCase,
     private val getFAQUseCase: GetFAQUseCase,
-    private val authTokenDataSource: AuthTokenDataSource
+    private val authTokenDataSourceImpl: AuthTokenDataSource
 ) : ViewModel() {
 
     val role = getRole().toString()
@@ -76,6 +76,6 @@ class FaqViewModel @Inject constructor(
     }
 
     private fun getRole(): Authority = runBlocking {
-        return@runBlocking authTokenDataSource.getAuthority().first()
+        return@runBlocking authTokenDataSourceImpl.getAuthority().first()
     }
 }

--- a/feature/post/src/main/java/com/msg/post/PostViewModel.kt
+++ b/feature/post/src/main/java/com/msg/post/PostViewModel.kt
@@ -5,7 +5,7 @@ import androidx.compose.runtime.mutableStateListOf
 import androidx.compose.runtime.mutableStateOf
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
-import com.msg.datastore.AuthTokenDataSource
+import com.msg.datastore.datasource.AuthTokenDataSource
 import com.msg.domain.post.DeletePostUseCase
 import com.msg.domain.post.EditPostUseCase
 import com.msg.domain.post.GetDetailPostUseCase
@@ -35,7 +35,7 @@ class PostViewModel @Inject constructor(
     private val getDetailPostUseCase: GetDetailPostUseCase,
     private val getPostListUseCase: GetPostListUseCase,
     private val sendPostUseCase: SendPostUseCase,
-    private val authTokenDataSource: AuthTokenDataSource
+    private val authTokenDataSourceImpl: AuthTokenDataSource
 ) : ViewModel() {
 
     private val _deletePostResponse = MutableStateFlow<Event<Unit>>(Event.Loading)
@@ -206,6 +206,6 @@ class PostViewModel @Inject constructor(
     }
 
     private fun getRole(): Authority = runBlocking {
-        return@runBlocking authTokenDataSource.getAuthority().first()
+        return@runBlocking authTokenDataSourceImpl.getAuthority().first()
     }
 }

--- a/feature/post/src/main/java/com/msg/post/PostViewModel.kt
+++ b/feature/post/src/main/java/com/msg/post/PostViewModel.kt
@@ -5,7 +5,7 @@ import androidx.compose.runtime.mutableStateListOf
 import androidx.compose.runtime.mutableStateOf
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
-import com.msg.datastore.datasource.AuthTokenDataSource
+import com.msg.data.repository.auth.AuthRepository
 import com.msg.domain.post.DeletePostUseCase
 import com.msg.domain.post.EditPostUseCase
 import com.msg.domain.post.GetDetailPostUseCase
@@ -35,7 +35,7 @@ class PostViewModel @Inject constructor(
     private val getDetailPostUseCase: GetDetailPostUseCase,
     private val getPostListUseCase: GetPostListUseCase,
     private val sendPostUseCase: SendPostUseCase,
-    private val authTokenDataSourceImpl: AuthTokenDataSource
+    private val authRepository: AuthRepository,
 ) : ViewModel() {
 
     private val _deletePostResponse = MutableStateFlow<Event<Unit>>(Event.Loading)
@@ -206,6 +206,6 @@ class PostViewModel @Inject constructor(
     }
 
     private fun getRole(): Authority = runBlocking {
-        return@runBlocking authTokenDataSourceImpl.getAuthority().first()
+        return@runBlocking authRepository.getAuthority().first()
     }
 }

--- a/feature/student-activity/src/main/java/com/msg/student_activity/viewmodel/StudentActivityViewModel.kt
+++ b/feature/student-activity/src/main/java/com/msg/student_activity/viewmodel/StudentActivityViewModel.kt
@@ -6,7 +6,7 @@ import androidx.compose.runtime.mutableStateListOf
 import androidx.compose.runtime.mutableStateOf
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
-import com.msg.datastore.AuthTokenDataSource
+import com.msg.datastore.datasource.AuthTokenDataSource
 import com.msg.domain.activity.AddStudentActivityInfoUseCase
 import com.msg.domain.activity.ApproveStudentActivityInfoUseCase
 import com.msg.domain.activity.DeleteStudentActivityInfoUseCase
@@ -46,7 +46,7 @@ class StudentActivityViewModel @Inject constructor(
     private val approveStudentActivityInfoUseCase: ApproveStudentActivityInfoUseCase,
     private val rejectStudentActivityInfoUseCase: RejectStudentActivityInfoUseCase,
     private val deleteStudentActivityInfoUseCase: DeleteStudentActivityInfoUseCase,
-    private val authTokenDataSource: AuthTokenDataSource
+    private val authTokenDataSourceImpl: AuthTokenDataSource
 ) : ViewModel() {
 
     val role = getRole().toString()
@@ -262,6 +262,6 @@ class StudentActivityViewModel @Inject constructor(
     }
 
     private fun getRole(): Authority = runBlocking {
-        return@runBlocking authTokenDataSource.getAuthority().first()
+        return@runBlocking authTokenDataSourceImpl.getAuthority().first()
     }
 }

--- a/feature/student-activity/src/main/java/com/msg/student_activity/viewmodel/StudentActivityViewModel.kt
+++ b/feature/student-activity/src/main/java/com/msg/student_activity/viewmodel/StudentActivityViewModel.kt
@@ -6,6 +6,7 @@ import androidx.compose.runtime.mutableStateListOf
 import androidx.compose.runtime.mutableStateOf
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
+import com.msg.data.repository.auth.AuthRepository
 import com.msg.datastore.datasource.AuthTokenDataSource
 import com.msg.domain.activity.AddStudentActivityInfoUseCase
 import com.msg.domain.activity.ApproveStudentActivityInfoUseCase
@@ -46,7 +47,7 @@ class StudentActivityViewModel @Inject constructor(
     private val approveStudentActivityInfoUseCase: ApproveStudentActivityInfoUseCase,
     private val rejectStudentActivityInfoUseCase: RejectStudentActivityInfoUseCase,
     private val deleteStudentActivityInfoUseCase: DeleteStudentActivityInfoUseCase,
-    private val authTokenDataSourceImpl: AuthTokenDataSource
+    private val authRepository: AuthRepository,
 ) : ViewModel() {
 
     val role = getRole().toString()
@@ -262,6 +263,6 @@ class StudentActivityViewModel @Inject constructor(
     }
 
     private fun getRole(): Authority = runBlocking {
-        return@runBlocking authTokenDataSourceImpl.getAuthority().first()
+        return@runBlocking authRepository.getAuthority().first()
     }
 }


### PR DESCRIPTION
## 💡 개요
AuthTokenDataSource가 의존성 역전 원칙을 위배하고 있어 인터페이스와 구현체로 나눠야합니다.
## 📃 작업내용
AuthTokenDataSource를 interface와 implementation class로 분리했습니다.
## 🔀 변경사항
기존 AuthTokenDataSource를 사용하던 파일의 인스턴스의 타입을 변경했습니다.
AuthRepository에 getAuthority함수를 추가했습니다.
## 🙋‍♂️ 질문사항
제가 잘못 구현한 부분이 있거나 불필요한 공백, 컨벤션에 맞지 않는 부분이 있다면 알려주세요.