### PR TITLE
🔀 :: (#220) DataSource내의 API 통신 요청 중복 로직 개선

### DIFF
--- a/core/network/src/main/java/com/msg/network/datasource/activity/ActivityDataSourceImpl.kt
+++ b/core/network/src/main/java/com/msg/network/datasource/activity/ActivityDataSourceImpl.kt
@@ -1,98 +1,50 @@
 package com.msg.network.datasource.activity
 
-import com.msg.network.response.activity.*
 import com.msg.model.model.activity.StudentActivityModel
 import com.msg.network.api.ActivityAPI
-import com.msg.network.util.BitgoeulApiHandler
-import kotlinx.coroutines.Dispatchers
+import com.msg.network.response.activity.*
+import com.msg.network.util.makeRequest
 import kotlinx.coroutines.flow.Flow
-import kotlinx.coroutines.flow.flow
-import kotlinx.coroutines.flow.flowOn
 import java.util.UUID
 import javax.inject.Inject
 
 class ActivityDataSourceImpl @Inject constructor(
     private val activityAPI: ActivityAPI
 ) : ActivityDataSource {
-    override fun addStudentActivityInfo(body: StudentActivityModel): Flow<Unit> = flow {
-        emit(
-            BitgoeulApiHandler<Unit>()
-                .httpRequest { activityAPI.addStudentActivityInfo(body = body) }
-                .sendRequest()
-        )
-    }.flowOn(Dispatchers.IO)
+    override fun addStudentActivityInfo(body: StudentActivityModel): Flow<Unit> =
+        makeRequest { activityAPI.addStudentActivityInfo(body = body) }
 
-    override fun editStudentActivityInfo(id: UUID, body: StudentActivityModel): Flow<Unit> = flow {
-        emit(
-            BitgoeulApiHandler<Unit>()
-                .httpRequest { activityAPI.editStudentActivityInfo(id = id, body = body) }
-                .sendRequest()
-        )
-    }.flowOn(Dispatchers.IO)
+    override fun editStudentActivityInfo(id: UUID, body: StudentActivityModel): Flow<Unit> =
+        makeRequest { activityAPI.editStudentActivityInfo(id = id, body = body) }
 
-    override fun approveStudentActivityInfo(id: UUID): Flow<Unit> = flow {
-        emit(
-            BitgoeulApiHandler<Unit>()
-                .httpRequest { activityAPI.approveStudentActivityInfo(id = id) }
-                .sendRequest()
-        )
-    }.flowOn(Dispatchers.IO)
+    override fun approveStudentActivityInfo(id: UUID): Flow<Unit> =
+        makeRequest { activityAPI.approveStudentActivityInfo(id = id) }
 
-    override fun rejectStudentActivityInfo(id: UUID): Flow<Unit> = flow {
-        emit(
-            BitgoeulApiHandler<Unit>()
-                .httpRequest { activityAPI.rejectStudentActivityInfo(id = id) }
-                .sendRequest()
-        )
-    }.flowOn(Dispatchers.IO)
+    override fun rejectStudentActivityInfo(id: UUID): Flow<Unit> =
+        makeRequest { activityAPI.rejectStudentActivityInfo(id = id) }
 
-    override fun deleteStudentActivityInfo(id: UUID): Flow<Unit> = flow {
-        emit(
-            BitgoeulApiHandler<Unit>()
-                .httpRequest { activityAPI.deleteStudentActivityInfo(id = id) }
-                .sendRequest()
-        )
-    }.flowOn(Dispatchers.IO)
+    override fun deleteStudentActivityInfo(id: UUID): Flow<Unit> =
+        makeRequest { activityAPI.deleteStudentActivityInfo(id = id) }
 
     override fun getMyStudentActivityInfoList(
         page: Int,
-        size: Int,
-    ): Flow<GetStudentActivityListResponse> = flow {
-        emit(
-            BitgoeulApiHandler<GetStudentActivityListResponse>()
-                .httpRequest { activityAPI.getMyStudentActivityInfoList(page = page, size = size) }
-                .sendRequest()
-        )
-    }.flowOn(Dispatchers.IO)
+        size: Int
+    ): Flow<GetStudentActivityListResponse> =
+        makeRequest { activityAPI.getMyStudentActivityInfoList(page = page, size = size) }
 
     override fun getStudentActivityInfoList(
         page: Int,
         size: Int,
         id: UUID
-    ): Flow<GetStudentActivityListResponse> = flow {
-        emit(
-            BitgoeulApiHandler<GetStudentActivityListResponse>()
-                .httpRequest { activityAPI.getStudentActivityInfoList(page = page, size = size, id = id) }
-                .sendRequest()
-        )
-    }.flowOn(Dispatchers.IO)
+    ): Flow<GetStudentActivityListResponse> =
+        makeRequest { activityAPI.getStudentActivityInfoList(page = page, size = size, id = id) }
 
     override fun getEntireStudentActivityInfoList(
         page: Int,
-        size: Int,
-    ): Flow<GetStudentActivityListResponse> = flow {
-        emit(
-            BitgoeulApiHandler<GetStudentActivityListResponse>()
-                .httpRequest { activityAPI.getEntireStudentActivityInfoList(page = page, size = size) }
-                .sendRequest()
-        )
-    }.flowOn(Dispatchers.IO)
+        size: Int
+    ): Flow<GetStudentActivityListResponse> =
+        makeRequest { activityAPI.getEntireStudentActivityInfoList(page = page, size = size) }
 
-    override fun getDetailStudentActivityInfo(id: UUID): Flow<GetDetailStudentActivityInfoResponse> = flow {
-        emit(
-            BitgoeulApiHandler<GetDetailStudentActivityInfoResponse>()
-                .httpRequest { activityAPI.getDetailStudentActivityInfo(id = id) }
-                .sendRequest()
-        )
-    }.flowOn(Dispatchers.IO)
+    override fun getDetailStudentActivityInfo(id: UUID): Flow<GetDetailStudentActivityInfoResponse> =
+        makeRequest { activityAPI.getDetailStudentActivityInfo(id = id) }
 }

--- a/core/network/src/main/java/com/msg/network/datasource/admin/AdminDataSourceImpl.kt
+++ b/core/network/src/main/java/com/msg/network/datasource/admin/AdminDataSourceImpl.kt
@@ -3,9 +3,8 @@ package com.msg.network.datasource.admin
 import com.msg.network.api.AdminAPI
 import com.msg.network.request.admin.GetUserListRequest
 import com.msg.network.response.admin.UserListResponse
-import com.msg.network.util.BitgoeulApiHandler
+import com.msg.network.util.makeRequest
 import kotlinx.coroutines.flow.Flow
-import kotlinx.coroutines.flow.flow
 import javax.inject.Inject
 
 class AdminDataSourceImpl @Inject constructor(
@@ -14,11 +13,6 @@ class AdminDataSourceImpl @Inject constructor(
     override fun getUserList(
         body: GetUserListRequest,
         keyword: String,
-    ): Flow<UserListResponse> = flow {
-        emit(
-            BitgoeulApiHandler<UserListResponse>()
-                .httpRequest { adminAPI.getUserList(body = body, keyword = keyword) }
-                .sendRequest()
-        )
-    }
+    ): Flow<UserListResponse> =
+        makeRequest { adminAPI.getUserList(body = body, keyword = keyword) }
 }

--- a/core/network/src/main/java/com/msg/network/datasource/auth/AuthDataSourceImpl.kt
+++ b/core/network/src/main/java/com/msg/network/datasource/auth/AuthDataSourceImpl.kt
@@ -3,94 +3,40 @@ package com.msg.network.datasource.auth
 import com.msg.network.api.AuthAPI
 import com.msg.network.request.auth.*
 import com.msg.network.response.auth.*
-import com.msg.network.util.BitgoeulApiHandler
-import kotlinx.coroutines.Dispatchers
+import com.msg.network.util.makeRequest
 import kotlinx.coroutines.flow.Flow
-import kotlinx.coroutines.flow.flow
-import kotlinx.coroutines.flow.flowOn
 import javax.inject.Inject
 
 class AuthDataSourceImpl @Inject constructor(
     private val authAPI: AuthAPI
 ) : AuthDataSource {
-    override fun login(body: LoginRequest): Flow<AuthTokenResponse> = flow {
-        emit(
-            BitgoeulApiHandler<AuthTokenResponse>()
-                .httpRequest { authAPI.login(body = body) }
-                .sendRequest()
-        )
-    }.flowOn(Dispatchers.IO)
+    override fun login(body: LoginRequest): Flow<AuthTokenResponse> =
+        makeRequest { authAPI.login(body = body) }
 
-    override fun signUpStudent(body: SignUpStudentRequest): Flow<Unit> = flow {
-        emit(
-            BitgoeulApiHandler<Unit>()
-                .httpRequest { authAPI.signUpStudent(body = body) }
-                .sendRequest()
-        )
-    }.flowOn(Dispatchers.IO)
+    override fun signUpStudent(body: SignUpStudentRequest): Flow<Unit> =
+        makeRequest { authAPI.signUpStudent(body = body) }
 
-    override fun signUpJobClubTeacher(body: SignUpJobClubTeacherRequest): Flow<Unit> = flow {
-        emit(
-            BitgoeulApiHandler<Unit>()
-                .httpRequest { authAPI.signUpJobClubTeacher(body = body) }
-                .sendRequest()
-        )
-    }.flowOn(Dispatchers.IO)
+    override fun signUpJobClubTeacher(body: SignUpJobClubTeacherRequest): Flow<Unit> =
+        makeRequest { authAPI.signUpJobClubTeacher(body = body) }
 
-    override fun signUpProfessor(body: SignUpProfessorRequest): Flow<Unit> = flow {
-        emit(
-            BitgoeulApiHandler<Unit>()
-                .httpRequest { authAPI.signUpProfessor(body = body) }
-                .sendRequest()
-        )
-    }.flowOn(Dispatchers.IO)
+    override fun signUpProfessor(body: SignUpProfessorRequest): Flow<Unit> =
+        makeRequest { authAPI.signUpProfessor(body = body) }
 
+    override fun signUpGovernment(body: SignUpGovernmentRequest): Flow<Unit> =
+        makeRequest { authAPI.signUpGovernment(body = body) }
 
-    override fun signUpGovernment(body: SignUpGovernmentRequest): Flow<Unit> = flow {
-        emit(
-            BitgoeulApiHandler<Unit>()
-                .httpRequest { authAPI.signUpGovernment(body = body) }
-                .sendRequest()
-        )
-    }.flowOn(Dispatchers.IO)
+    override fun signUpCompanyInstructor(body: SignUpCompanyInstructorRequest): Flow<Unit> =
+        makeRequest { authAPI.signUpCompanyInstructor(body = body) }
 
-    override fun signUpCompanyInstructor(body: SignUpCompanyInstructorRequest): Flow<Unit> = flow {
-        emit(
-            BitgoeulApiHandler<Unit>()
-                .httpRequest { authAPI.signUpCompanyInstructor(body = body) }
-                .sendRequest()
-        )
-    }.flowOn(Dispatchers.IO)
+    override fun signUpBbozzakTeacher(body: SignUpBbozzakTeacherRequest): Flow<Unit> =
+        makeRequest { authAPI.signUpBbozzakTeacher(body = body) }
 
-    override fun signUpBbozzakTeacher(body: SignUpBbozzakTeacherRequest): Flow<Unit> = flow {
-        emit(
-            BitgoeulApiHandler<Unit>()
-                .httpRequest { authAPI.signUpBbozzakTeacher(body = body) }
-                .sendRequest()
-        )
-    }.flowOn(Dispatchers.IO)
+    override fun findPassword(body: FindPasswordRequest): Flow<Unit> =
+        makeRequest { authAPI.findPassword(body = body) }
 
-    override fun findPassword(body: FindPasswordRequest): Flow<Unit> = flow {
-        emit(
-            BitgoeulApiHandler<Unit>()
-                .httpRequest { authAPI.findPassword(body = body) }
-                .sendRequest()
-        )
-    }.flowOn(Dispatchers.IO)
+    override fun logout(): Flow<Unit> =
+        makeRequest { authAPI.logout() }
 
-    override fun logout(): Flow<Unit> = flow {
-        emit(
-            BitgoeulApiHandler<Unit>()
-                .httpRequest { authAPI.logout() }
-                .sendRequest()
-        )
-    }.flowOn(Dispatchers.IO)
-
-    override fun withdraw(): Flow<Unit> = flow {
-        emit(
-            BitgoeulApiHandler<Unit>()
-                .httpRequest { authAPI.withdraw() }
-                .sendRequest()
-        )
-    }.flowOn(Dispatchers.IO)
+    override fun withdraw(): Flow<Unit> =
+        makeRequest { authAPI.withdraw() }
 }

--- a/core/network/src/main/java/com/msg/network/datasource/certification/CertificationDataSourceImpl.kt
+++ b/core/network/src/main/java/com/msg/network/datasource/certification/CertificationDataSourceImpl.kt
@@ -3,11 +3,8 @@ package com.msg.network.datasource.certification
 import com.msg.network.api.CertificationAPI
 import com.msg.network.request.certification.WriteCertificationRequest
 import com.msg.network.response.certification.CertificationListResponse
-import com.msg.network.util.BitgoeulApiHandler
-import kotlinx.coroutines.Dispatchers
+import com.msg.network.util.makeRequest
 import kotlinx.coroutines.flow.Flow
-import kotlinx.coroutines.flow.flow
-import kotlinx.coroutines.flow.flowOn
 import java.util.UUID
 import javax.inject.Inject
 
@@ -15,44 +12,14 @@ class CertificationDataSourceImpl @Inject constructor(
     private val certificationAPI: CertificationAPI,
 ) : CertificationDataSource {
     override fun getCertificationListForTeacher(studentId: UUID): Flow<List<CertificationListResponse>> =
-        flow {
-            emit(
-                BitgoeulApiHandler<List<CertificationListResponse>>()
-                    .httpRequest { certificationAPI.getCertificationListForTeacher(studentId = studentId) }
-                    .sendRequest()
-            )
-        }
+        makeRequest { certificationAPI.getCertificationListForTeacher(studentId = studentId) }
 
     override fun getCertificationListForStudent(): Flow<List<CertificationListResponse>> =
-        flow {
-            emit(
-                BitgoeulApiHandler<List<CertificationListResponse>>()
-                    .httpRequest { certificationAPI.getCertificationListForStudent() }
-                    .sendRequest()
-            )
-        }
+        makeRequest { certificationAPI.getCertificationListForStudent() }
 
-    override fun writeCertification(body: WriteCertificationRequest): Flow<Unit> = flow {
-        emit(
-            BitgoeulApiHandler<Unit>()
-                .httpRequest { certificationAPI.writeCertification(body = body) }
-                .sendRequest()
-        )
-    }.flowOn(Dispatchers.IO)
+    override fun writeCertification(body: WriteCertificationRequest): Flow<Unit> =
+        makeRequest { certificationAPI.writeCertification(body = body) }
 
-    override fun editCertification(
-        id: UUID,
-        body: WriteCertificationRequest,
-    ): Flow<Unit> = flow {
-        emit(
-            BitgoeulApiHandler<Unit>()
-                .httpRequest {
-                    certificationAPI.editCertification(
-                        id = id,
-                        body = body
-                    )
-                }
-                .sendRequest()
-        )
-    }.flowOn(Dispatchers.IO)
+    override fun editCertification(id: UUID, body: WriteCertificationRequest): Flow<Unit> =
+        makeRequest { certificationAPI.editCertification(id = id, body = body) }
 }

--- a/core/network/src/main/java/com/msg/network/datasource/club/ClubDataSourceImpl.kt
+++ b/core/network/src/main/java/com/msg/network/datasource/club/ClubDataSourceImpl.kt
@@ -3,44 +3,23 @@ package com.msg.network.datasource.club
 import com.msg.network.response.club.*
 import com.msg.model.enumdata.HighSchool
 import com.msg.network.api.ClubAPI
-import com.msg.network.util.BitgoeulApiHandler
+import com.msg.network.util.makeRequest
 import kotlinx.coroutines.flow.Flow
-import kotlinx.coroutines.flow.flow
 import java.util.UUID
 import javax.inject.Inject
 
 class ClubDataSourceImpl @Inject constructor(
     private val clubAPI: ClubAPI,
 ) : ClubDataSource {
-    override fun getClubList(highSchool: HighSchool): Flow<List<ClubListResponse>> = flow {
-        emit(
-            BitgoeulApiHandler<List<ClubListResponse>>()
-                .httpRequest { clubAPI.getClubList(highSchool = highSchool) }
-                .sendRequest()
-        )
-    }
+    override fun getClubList(highSchool: HighSchool): Flow<List<ClubListResponse>> =
+        makeRequest { clubAPI.getClubList(highSchool = highSchool) }
 
-    override fun getClubDetail(id: Long): Flow<ClubDetailResponse> = flow {
-        emit(
-            BitgoeulApiHandler<ClubDetailResponse>()
-                .httpRequest { clubAPI.getClubDetail(id = id) }
-                .sendRequest()
-        )
-    }
+    override fun getClubDetail(id: Long): Flow<ClubDetailResponse> =
+        makeRequest { clubAPI.getClubDetail(id = id) }
 
-    override fun getStudentBelongClubDetail(id: Long, studentId: UUID): Flow<StudentBelongClubResponse> = flow {
-        emit(
-            BitgoeulApiHandler<StudentBelongClubResponse>()
-                .httpRequest { clubAPI.getStudentBelongClubDetail(id = id, studentId = studentId) }
-                .sendRequest()
-        )
-    }
+    override fun getStudentBelongClubDetail(id: Long, studentId: UUID): Flow<StudentBelongClubResponse> =
+        makeRequest { clubAPI.getStudentBelongClubDetail(id = id, studentId = studentId) }
 
-    override fun getMyClubDetail(): Flow<ClubDetailResponse> = flow {
-        emit(
-            BitgoeulApiHandler<ClubDetailResponse>()
-                .httpRequest { clubAPI.getMyClubDetail() }
-                .sendRequest()
-        )
-    }
+    override fun getMyClubDetail(): Flow<ClubDetailResponse> =
+        makeRequest { clubAPI.getMyClubDetail() }
 }

--- a/core/network/src/main/java/com/msg/network/datasource/email/EmailDataSourceImpl.kt
+++ b/core/network/src/main/java/com/msg/network/datasource/email/EmailDataSourceImpl.kt
@@ -3,29 +3,16 @@ package com.msg.network.datasource.email
 import com.msg.network.api.EmailAPI
 import com.msg.network.request.email.SendLinkToEmailRequest
 import com.msg.network.response.email.GetEmailAuthenticateStatusResponse
-import com.msg.network.util.BitgoeulApiHandler
-import kotlinx.coroutines.Dispatchers
+import com.msg.network.util.makeRequest
 import kotlinx.coroutines.flow.Flow
-import kotlinx.coroutines.flow.flow
-import kotlinx.coroutines.flow.flowOn
 import javax.inject.Inject
 
 class EmailDataSourceImpl @Inject constructor(
     private val emailAPI: EmailAPI
 ) : EmailDataSource {
-    override fun sendLinkToEmail(body: SendLinkToEmailRequest): Flow<Unit> = flow {
-        emit(
-            BitgoeulApiHandler<Unit>()
-                .httpRequest { emailAPI.sendLinkToEmail(body = body) }
-                .sendRequest()
-        )
-    }.flowOn(Dispatchers.IO)
+    override fun sendLinkToEmail(body: SendLinkToEmailRequest): Flow<Unit> =
+        makeRequest { emailAPI.sendLinkToEmail(body = body) }
 
-    override fun getEmailAuthenticateStatus(email: String): Flow<GetEmailAuthenticateStatusResponse> = flow {
-        emit(
-            BitgoeulApiHandler<GetEmailAuthenticateStatusResponse>()
-                .httpRequest { emailAPI.getEmailAuthenticateStatus(email = email) }
-                .sendRequest()
-        )
-    }.flowOn(Dispatchers.IO)
+    override fun getEmailAuthenticateStatus(email: String): Flow<GetEmailAuthenticateStatusResponse> =
+        makeRequest { emailAPI.getEmailAuthenticateStatus(email = email) }
 }

--- a/core/network/src/main/java/com/msg/network/datasource/faq/FaqDataSourceImpl.kt
+++ b/core/network/src/main/java/com/msg/network/datasource/faq/FaqDataSourceImpl.kt
@@ -3,31 +3,16 @@ package com.msg.network.datasource.faq
 import com.msg.network.api.FaqAPI
 import com.msg.network.request.faq.AddFrequentlyAskedQuestionsRequest
 import com.msg.network.response.faq.GetFrequentlyAskedQuestionDetailResponse
-import com.msg.network.util.BitgoeulApiHandler
-import kotlinx.coroutines.Dispatchers
+import com.msg.network.util.makeRequest
 import kotlinx.coroutines.flow.Flow
-import kotlinx.coroutines.flow.flow
-import kotlinx.coroutines.flow.flowOn
 import javax.inject.Inject
 
 class FaqDataSourceImpl @Inject constructor(
     private val faqAPI: FaqAPI,
 ) : FaqDataSource {
     override fun addFrequentlyAskedQuestions(body: AddFrequentlyAskedQuestionsRequest): Flow<Unit> =
-        flow {
-            emit(
-                BitgoeulApiHandler<Unit>()
-                    .httpRequest { faqAPI.addFrequentlyAskedQuestions(body = body) }
-                    .sendRequest()
-            )
-        }.flowOn(Dispatchers.IO)
+        makeRequest { faqAPI.addFrequentlyAskedQuestions(body = body) }
 
     override fun getFrequentlyAskedQuestionsList(): Flow<List<GetFrequentlyAskedQuestionDetailResponse>> =
-        flow {
-            emit(
-                BitgoeulApiHandler<List<GetFrequentlyAskedQuestionDetailResponse>>()
-                    .httpRequest { faqAPI.getFrequentlyAskedQuestionsList() }
-                    .sendRequest()
-            )
-        }.flowOn(Dispatchers.IO)
+        makeRequest { faqAPI.getFrequentlyAskedQuestionsList() }
 }

--- a/core/network/src/main/java/com/msg/network/datasource/lecture/LectureDataSourceImpl.kt
+++ b/core/network/src/main/java/com/msg/network/datasource/lecture/LectureDataSourceImpl.kt
@@ -3,141 +3,50 @@ package com.msg.network.datasource.lecture
 import com.msg.network.response.lecture.*
 import com.msg.network.api.LectureAPI
 import com.msg.network.request.lecture.OpenLectureRequest
-import com.msg.network.util.BitgoeulApiHandler
-import kotlinx.coroutines.Dispatchers
+import com.msg.network.util.makeRequest
 import kotlinx.coroutines.flow.Flow
-import kotlinx.coroutines.flow.flow
-import kotlinx.coroutines.flow.flowOn
 import java.util.UUID
 import javax.inject.Inject
 
 class LectureDataSourceImpl @Inject constructor(
     private val lectureAPI: LectureAPI,
 ) : LectureDataSource {
-    override fun openLecture(body: OpenLectureRequest): Flow<Unit> = flow {
-        emit(
-            BitgoeulApiHandler<Unit>()
-                .httpRequest { lectureAPI.openLecture(body = body) }
-                .sendRequest()
-        )
-    }.flowOn(Dispatchers.IO)
+    override fun openLecture(body: OpenLectureRequest): Flow<Unit> =
+        makeRequest { lectureAPI.openLecture(body) }
 
-    override fun getLectureList(
-        page: Int,
-        size: Int,
-        type: String?,
-    ): Flow<LectureListResponse> = flow {
-        emit(
-            BitgoeulApiHandler<LectureListResponse>()
-                .httpRequest {
-                    lectureAPI.getLectureList(
-                        page = page,
-                        size = size,
-                        type = type
-                    )
-                }
-                .sendRequest()
-        )
-    }.flowOn(Dispatchers.IO)
+    override fun getLectureList(page: Int, size: Int, type: String?): Flow<LectureListResponse> =
+        makeRequest { lectureAPI.getLectureList(page, size, type) }
 
-    override fun getDetailLecture(id: UUID): Flow<DetailLectureResponse> = flow {
-        emit(
-            BitgoeulApiHandler<DetailLectureResponse>()
-                .httpRequest { lectureAPI.getDetailLecture(id = id) }
-                .sendRequest()
-        )
-    }.flowOn(Dispatchers.IO)
+    override fun getDetailLecture(id: UUID): Flow<DetailLectureResponse> =
+        makeRequest { lectureAPI.getDetailLecture(id) }
 
-    override fun lectureApplication(id: UUID): Flow<Unit> = flow {
-        emit(
-            BitgoeulApiHandler<Unit>()
-                .httpRequest { lectureAPI.lectureApplication(id = id) }
-                .sendRequest()
-        )
-    }.flowOn(Dispatchers.IO)
+    override fun lectureApplication(id: UUID): Flow<Unit> =
+        makeRequest { lectureAPI.lectureApplication(id) }
 
-    override fun lectureApplicationCancel(id: UUID): Flow<Unit> = flow {
-        emit(
-            BitgoeulApiHandler<Unit>()
-                .httpRequest { lectureAPI.lectureApplicationCancel(id = id) }
-                .sendRequest()
-        )
-    }.flowOn(Dispatchers.IO)
+    override fun lectureApplicationCancel(id: UUID): Flow<Unit> =
+        makeRequest { lectureAPI.lectureApplicationCancel(id) }
 
     override fun searchProfessor(keyword: String): Flow<SearchProfessorResponse> =
-        flow {
-            emit(
-                BitgoeulApiHandler<SearchProfessorResponse>()
-                    .httpRequest { lectureAPI.searchProfessor(keyword = keyword) }
-                    .sendRequest()
-            )
-        }.flowOn(Dispatchers.IO)
+        makeRequest { lectureAPI.searchProfessor(keyword) }
 
     override fun searchLine(keyword: String, division: String): Flow<SearchLineResponse> =
-        flow {
-            emit(
-                BitgoeulApiHandler<SearchLineResponse>()
-                    .httpRequest { lectureAPI.searchLine(keyword = keyword, division = division) }
-                    .sendRequest()
-            )
-        }.flowOn(Dispatchers.IO)
+        makeRequest { lectureAPI.searchLine(keyword, division) }
 
-    override fun searchDepartment(keyword: String): Flow<SearchDepartmentResponse> = flow {
-        emit(
-            BitgoeulApiHandler<SearchDepartmentResponse>()
-                .httpRequest { lectureAPI.searchDepartment(keyword = keyword) }
-                .sendRequest()
-        )
-    }.flowOn(Dispatchers.IO)
+    override fun searchDepartment(keyword: String): Flow<SearchDepartmentResponse> =
+        makeRequest { lectureAPI.searchDepartment(keyword) }
 
-    override fun searchDivision(keyword: String): Flow<SearchDivisionResponse> = flow {
-        emit(
-            BitgoeulApiHandler<SearchDivisionResponse>()
-                .httpRequest { lectureAPI.searchDivision(keyword = keyword) }
-                .sendRequest()
-        )
-    }.flowOn(Dispatchers.IO)
+    override fun searchDivision(keyword: String): Flow<SearchDivisionResponse> =
+        makeRequest { lectureAPI.searchDivision(keyword) }
 
     override fun getLectureSignUpHistory(studentId: UUID): Flow<GetLectureSignUpHistoryResponse> =
-        flow {
-            emit(
-                BitgoeulApiHandler<GetLectureSignUpHistoryResponse>()
-                    .httpRequest { lectureAPI.getLectureSignUpHistory(studentId = studentId) }
-                    .sendRequest()
-            )
-        }.flowOn(Dispatchers.IO)
+        makeRequest { lectureAPI.getLectureSignUpHistory(studentId) }
 
     override fun getTakingLectureStudentList(id: UUID): Flow<GetTakingLectureStudentListResponse> =
-        flow {
-            emit(
-                BitgoeulApiHandler<GetTakingLectureStudentListResponse>()
-                    .httpRequest { lectureAPI.getTakingLectureStudentList(id = id) }
-                    .sendRequest()
-            )
-        }.flowOn(Dispatchers.IO)
+        makeRequest { lectureAPI.getTakingLectureStudentList(id) }
 
     override fun editLectureCourseCompletionStatus(id: UUID, studentId: UUID, isComplete: Boolean): Flow<Unit> =
-        flow {
-            emit(
-                BitgoeulApiHandler<Unit>()
-                    .httpRequest {
-                        lectureAPI.editLectureCourseCompletionStatus(
-                            id = id,
-                            studentId = studentId,
-                            isComplete = isComplete
-                        )
-                    }
-                    .sendRequest()
-            )
-        }.flowOn(Dispatchers.IO)
+        makeRequest { lectureAPI.editLectureCourseCompletionStatus(id, studentId, isComplete) }
 
-    override fun downloadExcelFile(): Flow<DownloadExcelFileResponse> = flow {
-        emit(
-            BitgoeulApiHandler<DownloadExcelFileResponse>()
-                .httpRequest {
-                    lectureAPI.downloadExcelFile()
-                }
-                .sendRequest()
-        )
-    }.flowOn(Dispatchers.IO)
+    override fun downloadExcelFile(): Flow<DownloadExcelFileResponse> =
+        makeRequest { lectureAPI.downloadExcelFile() }
 }

--- a/core/network/src/main/java/com/msg/network/datasource/post/PostDataSourceImpl.kt
+++ b/core/network/src/main/java/com/msg/network/datasource/post/PostDataSourceImpl.kt
@@ -4,65 +4,26 @@ import com.msg.network.response.post.*
 import com.msg.network.request.post.WritePostRequest
 import com.msg.network.api.PostAPI
 import com.msg.model.enumdata.FeedType
-import com.msg.network.util.BitgoeulApiHandler
-import kotlinx.coroutines.Dispatchers
+import com.msg.network.util.makeRequest
 import kotlinx.coroutines.flow.Flow
-import kotlinx.coroutines.flow.flow
-import kotlinx.coroutines.flow.flowOn
 import java.util.UUID
 import javax.inject.Inject
 
 class PostDataSourceImpl @Inject constructor(
     private val postAPI: PostAPI
 ) : PostDataSource {
-    override fun sendPost(body: WritePostRequest): Flow<Unit> = flow {
-        emit(
-            BitgoeulApiHandler<Unit>()
-                .httpRequest { postAPI.sendPost(body = body) }
-                .sendRequest()
-        )
-    }.flowOn(Dispatchers.IO)
+    override fun sendPost(body: WritePostRequest): Flow<Unit> =
+        makeRequest { postAPI.sendPost(body = body) }
 
-    override fun getPostList(type: FeedType, size: Int, page: Int): Flow<GetPostListResponse> = flow {
-        emit(
-            BitgoeulApiHandler<GetPostListResponse>()
-                .httpRequest {
-                    postAPI.getPostList(
-                        type = type,
-                        size = size,
-                        page = page
-                    )
-                }
-                .sendRequest()
-        )
-    }.flowOn(Dispatchers.IO)
+    override fun getPostList(type: FeedType, size: Int, page: Int): Flow<GetPostListResponse> =
+        makeRequest { postAPI.getPostList(type = type, size = size, page = page) }
 
-    override fun getDetailPost(id: UUID): Flow<GetDetailPostResponse> = flow {
-        emit(
-            BitgoeulApiHandler<GetDetailPostResponse>()
-                .httpRequest { postAPI.getDetailPost(id = id) }
-                .sendRequest()
-        )
-    }.flowOn(Dispatchers.IO)
+    override fun getDetailPost(id: UUID): Flow<GetDetailPostResponse> =
+        makeRequest { postAPI.getDetailPost(id = id) }
 
-    override fun editPost(id: UUID, body: WritePostRequest): Flow<Unit> = flow {
-        emit(
-            BitgoeulApiHandler<Unit>()
-                .httpRequest {
-                    postAPI.editPost(
-                        id = id,
-                        body = body
-                    )
-                }
-                .sendRequest()
-        )
-    }.flowOn(Dispatchers.IO)
+    override fun editPost(id: UUID, body: WritePostRequest): Flow<Unit> =
+        makeRequest { postAPI.editPost(id = id, body = body) }
 
-    override fun deletePost(id: UUID): Flow<Unit> = flow {
-        emit(
-            BitgoeulApiHandler<Unit>()
-                .httpRequest { postAPI.deletePost(id = id) }
-                .sendRequest()
-        )
-    }.flowOn(Dispatchers.IO)
+    override fun deletePost(id: UUID): Flow<Unit> =
+        makeRequest { postAPI.deletePost(id = id) }
 }

--- a/core/network/src/main/java/com/msg/network/datasource/user/UserDataSourceImpl.kt
+++ b/core/network/src/main/java/com/msg/network/datasource/user/UserDataSourceImpl.kt
@@ -3,29 +3,16 @@ package com.msg.network.datasource.user
 import com.msg.network.api.UserAPI
 import com.msg.network.request.user.ChangePasswordRequest
 import com.msg.network.response.user.InquiryMyPageResponse
-import com.msg.network.util.BitgoeulApiHandler
-import kotlinx.coroutines.Dispatchers
+import com.msg.network.util.makeRequest
 import kotlinx.coroutines.flow.Flow
-import kotlinx.coroutines.flow.flow
-import kotlinx.coroutines.flow.flowOn
 import javax.inject.Inject
 
 class UserDataSourceImpl @Inject constructor(
     private val userAPI: UserAPI
 ) : UserDataSource {
-    override fun changePassword(body: ChangePasswordRequest): Flow<Unit> = flow {
-        emit(
-            BitgoeulApiHandler<Unit>()
-                .httpRequest { userAPI.changePassword(body = body) }
-                .sendRequest()
-        )
-    }.flowOn(Dispatchers.IO)
+    override fun changePassword(body: ChangePasswordRequest): Flow<Unit> =
+        makeRequest { userAPI.changePassword(body = body) }
 
-    override fun inquiryMyPage(): Flow<InquiryMyPageResponse> = flow {
-        emit(
-            BitgoeulApiHandler<InquiryMyPageResponse>()
-                .httpRequest { userAPI.inquiryMyPage() }
-                .sendRequest()
-        )
-    }
+    override fun inquiryMyPage(): Flow<InquiryMyPageResponse> =
+        makeRequest { userAPI.inquiryMyPage() }
 }

--- a/core/network/src/main/java/com/msg/network/util/BitgoeulApiHandler.kt
+++ b/core/network/src/main/java/com/msg/network/util/BitgoeulApiHandler.kt
@@ -1,7 +1,5 @@
 package com.msg.network.util
 
-import kotlinx.coroutines.Dispatchers
-import kotlinx.coroutines.withContext
 import retrofit2.HttpException
 import com.msg.common.exception.*
 import java.net.SocketTimeoutException
@@ -15,9 +13,7 @@ class BitgoeulApiHandler<T> {
 
     suspend fun sendRequest(): T {
         return try {
-            withContext(Dispatchers.IO) {
                 httpRequest.invoke()
-            }
         } catch (e: HttpException) {
             val message = e.message
             throw when(e.code()) {

--- a/core/network/src/main/java/com/msg/network/util/makeRequest.kt
+++ b/core/network/src/main/java/com/msg/network/util/makeRequest.kt
@@ -1,0 +1,12 @@
+package com.msg.network.util
+
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.flow
+import kotlinx.coroutines.flow.flowOn
+
+internal inline fun <reified T> makeRequest(crossinline apiCall: suspend () -> T): Flow<T> = flow {
+    emit(BitgoeulApiHandler<T>()
+        .httpRequest { apiCall() }
+        .sendRequest())
+}.flowOn(Dispatchers.IO)


### PR DESCRIPTION
## 💡 개요
DataSource의 API 통신 요청시 로직이 중복됩니다.
## 📃 작업내용
DataSource의 API 통신 요청시 로직을 generic, inline, crossinline, suspend lambda, reified 키워드를 사용하여 makeRequest라는 함수를 생성해 처리했습니다.
## 🔀 변경사항
DataSource들의 API 요청시 makeRequest함수를 사용해 요청하도록 로직을 변경했습니다.
network 모듈의 util패키지에 makeRequest함수가 추가됐습니다.
BitgoeulApiHandler 클래스의 Warning을 제거하기 위해 Dispatcher를 제거하고 일반적인 suspend 호출을 하게끔 변경했습니다.
## 🙋‍♂️ 질문사항
제가 잘못 구현한 부분이나 컨벤션에 맞지 않는 부분, 불필요한 공백이 있다면 알려주세요.