### PR TITLE
🔀 :: (#224) 뒤로가기 연속 클릭시 네비게이션 오류

### DIFF
--- a/app/src/main/java/com/msg/bitgoeul_android/navigation/BitgoeulNavHost.kt
+++ b/app/src/main/java/com/msg/bitgoeul_android/navigation/BitgoeulNavHost.kt
@@ -88,7 +88,7 @@ fun BitgoeulNavHost(
             onBackClicked = navController::navigateToLogin
         )
         signUpScreen(
-            onBackClicked = navController::popBackStack,
+            onBackClicked = navController::navigateUp,
             onEnterFinished = navController::navigateToSignUpFinish
         )
         signUpFinishScreen(
@@ -97,41 +97,41 @@ fun BitgoeulNavHost(
         studentActivityScreen(
             onAddClicked = navController::navigateToAddActivity,
             onItemClicked = navController::navigateToStudentDetailActivity,
-            onBackClicked = navController::popBackStack
+            onBackClicked = navController::navigateUp
         )
         studentDetailActivityScreen(
-            onActionEnd = navController::popBackStack,
+            onActionEnd = navController::navigateUp,
             onEditClicked = navController::navigateToAddActivity,
-            onBackClicked = navController::popBackStack
+            onBackClicked = navController::navigateUp
         )
         studentAddActivityScreen(
-            onActionClicked = navController::popBackStack,
+            onActionClicked = navController::navigateUp,
             onSettingClicked = navController::navigateToDetailSettingActivity,
-            onBackClicked = navController::popBackStack
+            onBackClicked = navController::navigateUp
         )
         studentDetailSettingActivityScreen(
-            onCloseClicked = navController::popBackStack,
-            onApplyClicked = navController::popBackStack
+            onCloseClicked = navController::navigateUp,
+            onApplyClicked = navController::navigateUp
         )
         lectureListScreen(
             onOpenClicked = navController::navigateToLectureOpen,
             onItemClicked = navController::navigateToLectureDetail,
         )
         lectureDetailScreen(
-            onBackClicked = navController::popBackStack,
+            onBackClicked = navController::navigateUp,
             onLectureTakingStudentListScreenClicked = navController::navigateToLectureTakingStudentList
         )
         lectureTakingStudentListScreen(
-            onBackClicked = navController::popBackStack,
+            onBackClicked = navController::navigateUp,
         )
         lectureOpenScreen(
-            onActionClicked = navController::popBackStack,
+            onActionClicked = navController::navigateUp,
             onSettingClicked = navController::navigateToLectureDetailSetting,
-            onBackClicked = navController::popBackStack,
+            onBackClicked = navController::navigateUp,
         )
         lectureDetailSettingScreen(
-            onCloseClicked = navController::popBackStack,
-            onApplyClicked = navController::popBackStack,
+            onCloseClicked = navController::navigateUp,
+            onApplyClicked = navController::navigateUp,
         )
         myPageScreen(
             onPasswordChangeClicked = navController::navigateToPasswordChange,
@@ -140,7 +140,7 @@ fun BitgoeulNavHost(
         )
         changePasswordScreen(
             onSuccessScreenButtonClicked = navController::navigateToMyPage,
-            onBackClicked = navController::popBackStack
+            onBackClicked = navController::navigateUp
         )
         postScreen(
             onItemClick = navController::navigateToPostDetailPage,
@@ -148,22 +148,22 @@ fun BitgoeulNavHost(
         )
         postDetailScreen(
             onEditClicked = navController::navigateToPostAddPage,
-            onDeleteClicked = navController::popBackStack,
-            onBackClicked = navController::popBackStack
+            onDeleteClicked = navController::navigateUp,
+            onBackClicked = navController::navigateUp
         )
         postAddScreen(
             onSettingClicked = navController::navigateToPostDetailSettingPage,
-            onBackClicked = navController::popBackStack,
-            onAddClicked = navController::popBackStack
+            onBackClicked = navController::navigateUp,
+            onAddClicked = navController::navigateUp
         )
         postDetailSettingScreen(
-            onCloseClicked = navController::popBackStack
+            onCloseClicked = navController::navigateUp
         )
         clubScreen(
             onItemClicked = navController::navigateToClubDetailPage
         )
         clubDetailScreen(
-            onBackClickedByAdmin = navController::popBackStack,
+            onBackClickedByAdmin = navController::navigateUp,
             onBackClicked = navController::navigateToMainPage
         )
         mainPageScreen(
@@ -174,7 +174,7 @@ fun BitgoeulNavHost(
             onEditClicked = navController::navigateToAddCertificationPage
         )
         addCertificationScreen(
-            onBackClicked = navController::popBackStack
+            onBackClicked = navController::navigateUp
         )
     }
 }


### PR DESCRIPTION
## 💡 개요
뒤로가기 엄청 빨리 클릭하면 화면이 사라졌습니다
[Screen_recording_20240613_135354.webm](https://github.com/School-of-Company/Bitgoeul-Android/assets/103114398/22bd0568-62d2-477d-9f76-6ae84f45e657)

## 📃 작업내용
기존 뒤로가기에서 사용하던 popBackStack은 백스택을 알지 못해서 마지막 화면이더라도 pop을 시도합니다
navigateUp은 popBackStack과 동일하게 작동하지만 현재 백스택을 인식합니다

수정 후
[Screen_recording_20240613_140018.webm](https://github.com/School-of-Company/Bitgoeul-Android/assets/103114398/7c069131-af72-4bed-b0a9-969c80ce708e)

## 🔀 변경사항
navhost에서 popBackStack을 navigateUp으로 변경

## 🎸 기타
[뒤로 이동하기 위해 popBackStack() 사용을 중단한 이유](https://www.youtube.com/watch?v=y2zLFONuk7c)