### PR TITLE
🔀 :: (#221) popUpTo Navigate 적용

### DIFF
--- a/app/src/main/java/com/msg/bitgoeul_android/navigation/BitgoeulNavHost.kt
+++ b/app/src/main/java/com/msg/bitgoeul_android/navigation/BitgoeulNavHost.kt
@@ -19,6 +19,7 @@ import com.example.my_page.navigation.myPageScreen
 import com.example.my_page.navigation.navigateToMyPage
 import com.example.my_page.navigation.navigateToPasswordChange
 import com.msg.bitgoeul_android.ui.BitgoeulAppState
+import com.msg.bitgoeul_android.ui.navigateWithPopUpToLogin
 import com.msg.certification.navigation.addCertificationScreen
 import com.msg.certification.navigation.certificationScreen
 import com.msg.certification.navigation.navigateToAddCertificationPage
@@ -73,7 +74,7 @@ fun BitgoeulNavHost(
             onLoginClicked = navController::navigateToMainPage
         )
         inputEmailScreen(
-            onBackClicked = navController::navigateToLogin,
+            onBackClicked = { navController.navigateWithPopUpToLogin(loginRoute) },
             onNextClicked = navController::navigateToEmailSendInform
         )
         emailSendInformScreen(

--- a/app/src/main/java/com/msg/bitgoeul_android/ui/BitgoeulAppState.kt
+++ b/app/src/main/java/com/msg/bitgoeul_android/ui/BitgoeulAppState.kt
@@ -7,6 +7,7 @@ import androidx.compose.runtime.Stable
 import androidx.compose.runtime.remember
 import androidx.compose.runtime.rememberCoroutineScope
 import androidx.compose.ui.util.trace
+import androidx.navigation.NavController
 import androidx.navigation.NavDestination
 import androidx.navigation.NavGraph.Companion.findStartDestination
 import androidx.navigation.NavHostController
@@ -30,7 +31,7 @@ import kotlinx.coroutines.CoroutineScope
 fun rememberBitgoeulAppState(
     windowSizeClass: WindowSizeClass,
     coroutineScope: CoroutineScope = rememberCoroutineScope(),
-    navController: NavHostController = rememberNavController()
+    navController: NavHostController = rememberNavController(),
 ): BitgoeulAppState {
     return remember(
         navController,
@@ -49,7 +50,7 @@ fun rememberBitgoeulAppState(
 class BitgoeulAppState(
     val navController: NavHostController,
     val coroutineScope: CoroutineScope,
-    val windowSizeClass: WindowSizeClass
+    val windowSizeClass: WindowSizeClass,
 ) {
     val currentDestination: NavDestination?
         @Composable get() = navController
@@ -87,5 +88,11 @@ class BitgoeulAppState(
                 TopLevelDestination.MY_PAGE -> navController.navigateToMyPage(topLevelNavOptions)
             }
         }
+    }
+}
+
+fun NavController.navigateWithPopUpToLogin(loginRoute: String) {
+    this.navigate(loginRoute) {
+        popUpTo(loginRoute) { inclusive = true }
     }
 }


### PR DESCRIPTION
## 💡 개요
Login으로 바로 이동하게 하지 않고 이전 스택을 삭제하는 popUpTo 를 적용해야합니다
## 📃 작업내용
이전 스택을 삭제하는 popUpTo 를 적용했습니다.
## 🔀 변경사항
BitgoeulAppState에 popUpTo 함수가 추가됐습니다.
BitgoeulNavHost inputEmainScreen에 LoginRoute로 이동하는 popUpTo 함수를 적용했습니다.
## 🙋‍♂️ 질문사항
popUpTo 메서드 레퍼런스로 사용하고 싶었지만 람다식을 펼쳐 고차함수로 받는 방식이 최선인 것 같습니다. 더 좋은 방식이 있다면 알려주세요.