### PR TITLE
🔀 :: (#240) 강의 상세 정보 페이지 카카오맵 추가

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,4 +7,5 @@
 /captures
 .externalNativeBuild
 .cxx
+core/design-system/src/main/res/values/bitgoeul_app_key.xml
 local.properties

--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -27,6 +27,7 @@ dependencies {
     implementation(project(":feature:main"))
     implementation(project(":feature:certification"))
 
+    implementation(libs.kakao.maps)
     implementation(libs.junit)
     androidTestImplementation(libs.androidx.test.ext)
 }

--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -4,6 +4,8 @@
 
     <uses-permission android:name="android.permission.VIBRATE" />
     <uses-permission android:name="android.permission.INTERNET" />
+    <uses-permission android:name="android.permission.ACCESS_FINE_LOCATION" />
+    <uses-permission android:name="android.permission.ACCESS_COARSE_LOCATION" />
     <uses-permission android:name="android.permission.WRITE_EXTERNAL_STORAGE" />
     <uses-permission android:name="android.permission.READ_EXTERNAL_STORAGE" />
 
@@ -19,6 +21,11 @@
         android:supportsRtl="true"
         android:theme="@style/Theme.BitgoeulAndroid"
         tools:targetApi="31">
+
+        <meta-data
+            android:name="com.kakao.sdk.AppKey"
+            android:value="@string/app_key" />
+
         <activity
             android:name=".MainActivity"
             android:exported="true"

--- a/app/src/main/java/com/msg/bitgoeul_android/MainActivity.kt
+++ b/app/src/main/java/com/msg/bitgoeul_android/MainActivity.kt
@@ -6,12 +6,19 @@ import androidx.activity.compose.setContent
 import androidx.compose.material3.windowsizeclass.ExperimentalMaterial3WindowSizeClassApi
 import androidx.compose.material3.windowsizeclass.calculateWindowSizeClass
 import androidx.compose.runtime.CompositionLocalProvider
+import com.kakao.vectormap.KakaoMapSdk
 import com.msg.bitgoeul_android.ui.BitgoeulApp
 import com.msg.design_system.theme.BitgoeulAndroidTheme
 import dagger.hilt.android.AndroidEntryPoint
+import javax.inject.Inject
+import javax.inject.Named
 
 @AndroidEntryPoint
 class MainActivity : ComponentActivity() {
+    @Inject
+    @Named("NATIVE_APP_KEY")
+    lateinit var nativeAppKey: String
+
     @OptIn(ExperimentalMaterial3WindowSizeClassApi::class)
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
@@ -22,5 +29,6 @@ class MainActivity : ComponentActivity() {
                 }
             }
         }
+        KakaoMapSdk.init(this@MainActivity, nativeAppKey)
     }
 }

--- a/core/common/src/main/java/com/msg/common/errorhandling/errorHandling.kt
+++ b/core/common/src/main/java/com/msg/common/errorhandling/errorHandling.kt
@@ -72,5 +72,5 @@ suspend fun <T> Throwable.errorHandling(
     }
 
 private fun errorLog(tag: String, msg: String?) {
-    Log.d("ErrorHandling-$tag", msg ?: "알 수 없는 오류")
+    Log.e("ErrorHandling-$tag", msg ?: "알 수 없는 오류")
 }

--- a/core/data/src/main/java/com/msg/data/mapper/lecture/DetailLectureMapper.kt
+++ b/core/data/src/main/java/com/msg/data/mapper/lecture/DetailLectureMapper.kt
@@ -1,6 +1,7 @@
 package com.msg.data.mapper.lecture
 
 import com.msg.model.entity.lecture.DetailLectureEntity
+import com.msg.model.model.lecture.LectureDates as DomainLectureDates
 import com.msg.network.response.lecture.DetailLectureResponse
 
 fun DetailLectureResponse.toEntity() = DetailLectureEntity(
@@ -13,7 +14,7 @@ fun DetailLectureResponse.toEntity() = DetailLectureEntity(
     createAt = createAt,
     startDate = startDate,
     endDate = endDate,
-    lectureDates = lectureDates,
+    lectureDates = lectureDates.map { it.toDomainLectureDates() },
     lectureType = lectureType,
     lectureStatus = lectureStatus,
     headCount = headCount,
@@ -26,4 +27,10 @@ fun DetailLectureResponse.toEntity() = DetailLectureEntity(
     address = address,
     locationDetails = locationDetails,
     essentialComplete = essentialComplete
+)
+
+fun DetailLectureResponse.LectureDates.toDomainLectureDates() = DomainLectureDates(
+    completeDate = completeDate,
+    startTime = startTime,
+    endTime = endTime
 )

--- a/core/data/src/main/java/com/msg/data/repository/lecture/LectureRepositoryImpl.kt
+++ b/core/data/src/main/java/com/msg/data/repository/lecture/LectureRepositoryImpl.kt
@@ -45,7 +45,7 @@ class LectureRepositoryImpl @Inject constructor(
         return lectureDataSource.getDetailLecture(
             id = id
         ).transform { response ->
-            response.toEntity()
+            emit(response.toEntity())
         }
     }
 

--- a/core/design-system/src/main/res/drawable/ic_new_bitgoeul.xml
+++ b/core/design-system/src/main/res/drawable/ic_new_bitgoeul.xml
@@ -1,0 +1,46 @@
+<vector xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:aapt="http://schemas.android.com/aapt"
+    android:width="256dp"
+    android:height="256dp"
+    android:viewportWidth="256"
+    android:viewportHeight="256">
+  <group>
+    <clip-path
+        android:pathData="M0,0h256v256h-256z"/>
+    <path
+        android:pathData="M0,0h256v256h-256z"
+        android:fillColor="#2270C1"/>
+    <path
+        android:pathData="M216.24,40.37C218.01,39.62 219.72,41.57 218.74,43.23L150.82,158.35C149.88,159.95 147.95,160.69 146.18,160.13L138.07,157.59L132.5,155.83L126.93,154.08L89.96,142.45L86.79,141.46L83.82,140.52L29.56,123.46C27.78,122.9 27.67,120.43 29.38,119.71L216.24,40.37Z"
+        android:fillColor="#ffffff"/>
+    <path
+        android:pathData="M132.5,155.83L126.93,154.08L89.96,142.45L96.87,197.21C97.09,198.99 99.37,199.6 100.45,198.17L132.5,155.83Z"
+        android:fillColor="#ffffff"/>
+    <path
+        android:pathData="M132.5,155.83L126.93,154.08L89.96,142.45L96.87,197.21C97.09,198.99 99.37,199.6 100.45,198.17L132.5,155.83Z">
+      <aapt:attr name="android:fillColor">
+        <gradient 
+            android:startX="85.76"
+            android:startY="176.23"
+            android:endX="142.3"
+            android:endY="139.86"
+            android:type="linear">
+          <item android:offset="0.3" android:color="#FFFFFFFF"/>
+          <item android:offset="1" android:color="#FFA9A9A9"/>
+        </gradient>
+      </aapt:attr>
+    </path>
+    <path
+        android:pathData="M96.88,197.32L89.96,142.45L218.28,40.66L83.82,140.52L96.88,197.32Z"
+        android:fillColor="#A9A9A9"/>
+    <path
+        android:pathData="M-44.5,155C-1.7,139 46,146.33 64.5,152C36.5,163 -22,190.2 -32,211C-42,231.8 -61.5,205.67 -70,190L-44.5,155Z"
+        android:fillColor="#4DBE4B"/>
+    <path
+        android:pathData="M136.5,271C116,252.5 116.5,216.5 144,172C147,222.5 182.01,259.5 197.01,271L161.51,285.5L136.5,271Z"
+        android:fillColor="#F1511B"/>
+    <path
+        android:pathData="M-3,225.5C31.4,221.9 41,223.5 84,193.5C63.5,233 84,278.5 78.5,306C65.53,314.55 11.08,288.83 2,287.5C-17.17,275.67 -37.4,229.1 -3,225.5Z"
+        android:fillColor="#FAB220"/>
+  </group>
+</vector>

--- a/core/design-system/src/main/res/values/bitgoeul_app_key.xml
+++ b/core/design-system/src/main/res/values/bitgoeul_app_key.xml
@@ -1,0 +1,4 @@
+<?xml version="1.0" encoding="utf-8"?>
+<resources>
+    <string name="app_key">237453a51220adf0b261dfee45fa1508</string>
+</resources>

--- a/core/domain/src/main/java/com/msg/domain/usecase/lecture/GetDetailLectureUseCase.kt
+++ b/core/domain/src/main/java/com/msg/domain/usecase/lecture/GetDetailLectureUseCase.kt
@@ -7,7 +7,7 @@ import javax.inject.Inject
 class GetDetailLectureUseCase @Inject constructor(
     private val lectureRepository: LectureRepository
 ) {
-    suspend operator fun invoke(id: UUID) = runCatching {
+    operator fun invoke(id: UUID) = runCatching {
         lectureRepository.getDetailLecture(id = id)
     }
 }

--- a/core/model/src/main/java/com/msg/model/entity/lecture/DetailLectureEntity.kt
+++ b/core/model/src/main/java/com/msg/model/entity/lecture/DetailLectureEntity.kt
@@ -2,7 +2,6 @@ package com.msg.model.entity.lecture
 
 import com.msg.model.enumdata.LectureStatus
 import com.msg.model.model.lecture.LectureDates
-import java.time.LocalDate
 import java.time.LocalDateTime
 
 data class DetailLectureEntity(
@@ -12,7 +11,7 @@ data class DetailLectureEntity(
     val division: String,
     val department: String,
     val line: String,
-    val createAt: LocalDate,
+    val createAt: LocalDateTime,
     val startDate: LocalDateTime,
     val endDate: LocalDateTime,
     val lectureDates: List<LectureDates>,

--- a/core/network/build.gradle.kts
+++ b/core/network/build.gradle.kts
@@ -42,5 +42,5 @@ fun getApiKey(propertyKey: String): String {
     val propFile = rootProject.file("./local.properties")
     val properties = Properties()
     properties.load(FileInputStream(propFile))
-    return properties.getProperty(propertyKey)
+    return properties.getProperty(propertyKey) ?: throw IllegalArgumentException("Property $propertyKey not found in local.properties")
 }

--- a/core/network/build.gradle.kts
+++ b/core/network/build.gradle.kts
@@ -15,6 +15,7 @@ android {
 
     defaultConfig {
         buildConfigField("String", "BASE_URL",  getApiKey("BASE_URL"))
+        buildConfigField("String", "NATIVE_APP_KEY", getApiKey("NATIVE_APP_KEY"))
     }
 
     namespace = "com.msg.network"

--- a/core/network/src/main/java/com/msg/network/di/AppConfigModule.kt
+++ b/core/network/src/main/java/com/msg/network/di/AppConfigModule.kt
@@ -1,0 +1,16 @@
+package com.msg.network.di
+
+import com.msg.network.BuildConfig
+import dagger.Module
+import dagger.Provides
+import dagger.hilt.InstallIn
+import dagger.hilt.components.SingletonComponent
+import javax.inject.Named
+
+@Module
+@InstallIn(SingletonComponent::class)
+object AppConfigModule {
+    @Provides
+    @Named("NATIVE_APP_KEY")
+    fun provideNativeAppKey(): String = BuildConfig.NATIVE_APP_KEY
+}

--- a/core/network/src/main/java/com/msg/network/di/NetworkModule.kt
+++ b/core/network/src/main/java/com/msg/network/di/NetworkModule.kt
@@ -15,6 +15,9 @@ import com.msg.network.api.PostAPI
 import com.msg.network.api.SchoolAPI
 import com.msg.network.api.UserAPI
 import com.msg.network.util.AuthInterceptor
+import com.msg.network.util.LocalDateAdapter
+import com.msg.network.util.LocalDateTimeAdapter
+import com.msg.network.util.LocalTimeAdapter
 import com.msg.network.util.UUIDAdapter
 import com.squareup.moshi.Moshi
 import com.squareup.moshi.kotlin.reflect.KotlinJsonAdapterFactory
@@ -26,7 +29,6 @@ import okhttp3.OkHttpClient
 import okhttp3.logging.HttpLoggingInterceptor
 import retrofit2.Retrofit
 import retrofit2.converter.moshi.MoshiConverterFactory
-import retrofit2.create
 import java.util.concurrent.TimeUnit
 import javax.inject.Singleton
 
@@ -56,7 +58,12 @@ object NetworkModule {
     @Provides
     @Singleton
     fun provideMoshiInstance(): Moshi {
-        return Moshi.Builder().add(UUIDAdapter()).add(KotlinJsonAdapterFactory()).build()
+        return Moshi.Builder()
+            .add(UUIDAdapter())
+            .add(LocalDateAdapter())
+            .add(LocalTimeAdapter())
+            .add(LocalDateTimeAdapter())
+            .add(KotlinJsonAdapterFactory()).build()
     }
 
     @Provides

--- a/core/network/src/main/java/com/msg/network/response/lecture/DetailLectureResponse.kt
+++ b/core/network/src/main/java/com/msg/network/response/lecture/DetailLectureResponse.kt
@@ -1,10 +1,11 @@
 package com.msg.network.response.lecture
 
 import com.msg.model.enumdata.LectureStatus
-import com.msg.model.model.lecture.LectureDates
 import com.squareup.moshi.Json
 import com.squareup.moshi.JsonClass
+import java.time.LocalDate
 import java.time.LocalDateTime
+import java.time.LocalTime
 
 @JsonClass(generateAdapter = true)
 data class DetailLectureResponse(
@@ -30,4 +31,11 @@ data class DetailLectureResponse(
     @Json(name = "address") val address: String,
     @Json(name = "locationDetails") val locationDetails: String,
     @Json(name = "essentialComplete") val essentialComplete: Boolean,
-)
+) {
+    @JsonClass(generateAdapter = true)
+    data class LectureDates(
+        @Json(name = "completeDate") val completeDate: LocalDate,
+        @Json(name = "startTime") val startTime: LocalTime,
+        @Json(name = "endTime") val endTime: LocalTime
+    )
+}

--- a/core/network/src/main/java/com/msg/network/response/lecture/DetailLectureResponse.kt
+++ b/core/network/src/main/java/com/msg/network/response/lecture/DetailLectureResponse.kt
@@ -4,7 +4,6 @@ import com.msg.model.enumdata.LectureStatus
 import com.msg.model.model.lecture.LectureDates
 import com.squareup.moshi.Json
 import com.squareup.moshi.JsonClass
-import java.time.LocalDate
 import java.time.LocalDateTime
 
 @JsonClass(generateAdapter = true)
@@ -15,7 +14,7 @@ data class DetailLectureResponse(
     @Json(name = "division") val division: String,
     @Json(name = "department") val department: String,
     @Json(name = "line") val line: String,
-    @Json(name = "createAt") val createAt: LocalDate,
+    @Json(name = "createAt") val createAt: LocalDateTime,
     @Json(name = "startDate") val startDate: LocalDateTime,
     @Json(name = "endDate") val endDate: LocalDateTime,
     @Json(name = "lectureDates") val lectureDates: List<LectureDates>,

--- a/core/network/src/main/java/com/msg/network/util/AuthInterceptor.kt
+++ b/core/network/src/main/java/com/msg/network/util/AuthInterceptor.kt
@@ -72,7 +72,6 @@ class AuthInterceptor @Inject constructor(
             if (method == "DELETE") {
                 builder.addHeader("RefreshToken", "Bearer $refreshToken")
             }
-            builder.addHeader("Authorization", "Bearer $accessToken")
         }
         return chain.proceed(builder.build())
     }

--- a/core/network/src/main/java/com/msg/network/util/LocalDateAdapter.kt
+++ b/core/network/src/main/java/com/msg/network/util/LocalDateAdapter.kt
@@ -1,0 +1,20 @@
+package com.msg.network.util
+
+import com.squareup.moshi.FromJson
+import com.squareup.moshi.ToJson
+import java.time.LocalDate
+import java.time.format.DateTimeFormatter
+
+class LocalDateAdapter {
+    private val formatter = DateTimeFormatter.ofPattern("yyyy-MM-dd")
+
+    @FromJson
+    fun fromJson(json: String): LocalDate {
+        return LocalDate.parse(json, formatter)
+    }
+
+    @ToJson
+    fun toJson(value: LocalDate): String {
+        return value.format(formatter)
+    }
+}

--- a/core/network/src/main/java/com/msg/network/util/LocalDateTimeAdapter.kt
+++ b/core/network/src/main/java/com/msg/network/util/LocalDateTimeAdapter.kt
@@ -1,0 +1,27 @@
+package com.msg.network.util
+
+import android.util.Log
+import com.squareup.moshi.FromJson
+import com.squareup.moshi.ToJson
+import java.time.LocalDateTime
+import java.time.format.DateTimeFormatter
+import java.time.format.DateTimeParseException
+
+class LocalDateTimeAdapter {
+    private val formatter = DateTimeFormatter.ofPattern("yyyy-MM-dd'T'HH:mm:ss.SSSSSS")
+
+    @FromJson
+    fun fromJson(json: String): LocalDateTime {
+        return try {
+            Log.e("fromJson parsing block", "실행")
+            LocalDateTime.parse(json, formatter)
+        } catch (e: DateTimeParseException) {
+            LocalDateTime.parse(json, DateTimeFormatter.ISO_LOCAL_DATE_TIME)
+        }
+    }
+
+    @ToJson
+    fun toJson(value: LocalDateTime): String {
+        return value.format(formatter)
+    }
+}

--- a/core/network/src/main/java/com/msg/network/util/LocalDateTimeAdapter.kt
+++ b/core/network/src/main/java/com/msg/network/util/LocalDateTimeAdapter.kt
@@ -13,7 +13,6 @@ class LocalDateTimeAdapter {
     @FromJson
     fun fromJson(json: String): LocalDateTime {
         return try {
-            Log.e("fromJson parsing block", "실행")
             LocalDateTime.parse(json, formatter)
         } catch (e: DateTimeParseException) {
             LocalDateTime.parse(json, DateTimeFormatter.ISO_LOCAL_DATE_TIME)

--- a/core/network/src/main/java/com/msg/network/util/LocalTimeAdapter.kt
+++ b/core/network/src/main/java/com/msg/network/util/LocalTimeAdapter.kt
@@ -1,0 +1,20 @@
+package com.msg.network.util
+
+import com.squareup.moshi.FromJson
+import com.squareup.moshi.ToJson
+import java.time.LocalTime
+import java.time.format.DateTimeFormatter
+
+class LocalTimeAdapter {
+    private val formatter = DateTimeFormatter.ofPattern("HH:mm:ss")
+
+    @FromJson
+    fun fromJson(json: String): LocalTime {
+        return LocalTime.parse(json, formatter)
+    }
+
+    @ToJson
+    fun toJson(value: LocalTime): String {
+        return value.format(formatter)
+    }
+}

--- a/feature/lecture/build.gradle.kts
+++ b/feature/lecture/build.gradle.kts
@@ -8,4 +8,5 @@ android {
 }
 
 dependencies {
+    implementation(libs.kakao.maps)
 }

--- a/feature/lecture/src/main/java/com/msg/lecture/LectureDetailScreen.kt
+++ b/feature/lecture/src/main/java/com/msg/lecture/LectureDetailScreen.kt
@@ -149,7 +149,7 @@ internal fun LectureDetailScreen(
                 Spacer(modifier = modifier.height(24.dp))
 
                 Text(
-                    text = "# " + data.lectureType,
+                    text = "# ${data.lectureType}",
                     color = colors.P3,
                     style = typography.labelMedium,
                 )
@@ -160,7 +160,7 @@ internal fun LectureDetailScreen(
                     modifier = modifier.fillMaxWidth()
                 ) {
                     Text(
-                        text = data.division,
+                        text = "${data.division}",
                         color = colors.G2,
                         style = typography.labelMedium
                     )
@@ -176,7 +176,7 @@ internal fun LectureDetailScreen(
                     Spacer(modifier = modifier.width(8.dp))
 
                     Text(
-                        text = data.line,
+                        text = "${data.line}",
                         color = colors.G2,
                         style = typography.labelMedium
                     )
@@ -193,7 +193,7 @@ internal fun LectureDetailScreen(
 
 
                     Text(
-                        text = data.department + " 학과",
+                        text = "${data.department} 학과",
                         color = colors.G2,
                         style = typography.labelMedium
                     )
@@ -203,7 +203,7 @@ internal fun LectureDetailScreen(
                 Spacer(modifier = modifier.height(4.dp))
 
                 Text(
-                    text = data.name,
+                    text = "${data.name}",
                     color = colors.BLACK,
                     style = typography.bodyLarge,
                 )
@@ -216,7 +216,7 @@ internal fun LectureDetailScreen(
                 ) {
 
                     Text(
-                        text = data.semester,
+                        text = "${data.semester}",
                         color = colors.G2,
                         style = typography.labelMedium
                     )

--- a/feature/lecture/src/main/java/com/msg/lecture/LectureDetailScreen.kt
+++ b/feature/lecture/src/main/java/com/msg/lecture/LectureDetailScreen.kt
@@ -365,7 +365,7 @@ internal fun LectureDetailScreen(
                     style = typography.bodySmall
                 )
             }
-            when(role) {
+            when (role) {
                 "ROLE_ADMIN" -> {
                     BitgoeulButton(
                         text = "수강 명단 확인",

--- a/feature/lecture/src/main/java/com/msg/lecture/LectureDetailScreen.kt
+++ b/feature/lecture/src/main/java/com/msg/lecture/LectureDetailScreen.kt
@@ -385,7 +385,9 @@ internal fun LectureDetailScreen(
 
                 LectureStatus.CLOSED -> {
                     Column(
-                        modifier = modifier.fillMaxSize(),
+                        modifier = modifier
+                            .padding(horizontal = 24.dp)
+                            .fillMaxSize(),
                         verticalArrangement = Arrangement.Bottom
                     ) {
                         Box(

--- a/feature/lecture/src/main/java/com/msg/lecture/LectureDetailScreen.kt
+++ b/feature/lecture/src/main/java/com/msg/lecture/LectureDetailScreen.kt
@@ -337,9 +337,11 @@ internal fun LectureDetailScreen(
             }
 
             when (data.lectureStatus) {
-                LectureStatus.OPENED  -> {
+                LectureStatus.OPENED -> {
                     Column(
-                        modifier = modifier.fillMaxSize(),
+                        modifier = modifier
+                            .fillMaxSize()
+                            .padding(horizontal = 24.dp),
                         verticalArrangement = Arrangement.Bottom
                     ) {
                         Box(

--- a/feature/lecture/src/main/java/com/msg/lecture/LectureDetailScreen.kt
+++ b/feature/lecture/src/main/java/com/msg/lecture/LectureDetailScreen.kt
@@ -54,22 +54,22 @@ internal fun LectureDetailRoute(
     onLectureTakingStudentListScreenClicked: () -> Unit,
     viewModel: LectureViewModel = hiltViewModel(LocalContext.current as ComponentActivity),
 ) {
-    val id = viewModel.selectedLectureId.value
     val role = viewModel.role
+    val lectureDetailData = viewModel.lectureDetailData
 
-    LaunchedEffect(true) {
-        viewModel.getDetailLecture(id = id)
+
+    LaunchedEffect(Unit) {
         getLectureDetailData(
             viewModel = viewModel,
             onSuccess = { lectureDetailData ->
-                viewModel.lectureDetailData.value = lectureDetailData
+                viewModel.setLectureDetailData(lectureDetailData)
             }
         )
     }
 
     LectureDetailScreen(
         role = role,
-        data = viewModel.lectureDetailData.value,
+        data = lectureDetailData.value,
         onBackClicked = onBackClicked,
         onLectureTakingStudentListScreenClicked = onLectureTakingStudentListScreenClicked,
         onApplicationCancelClicked = {

--- a/feature/lecture/src/main/java/com/msg/lecture/LectureDetailScreen.kt
+++ b/feature/lecture/src/main/java/com/msg/lecture/LectureDetailScreen.kt
@@ -38,6 +38,7 @@ import com.msg.design_system.component.icon.KebabIcon
 import com.msg.design_system.component.topbar.GoBackTopBar
 import com.msg.design_system.theme.BitgoeulAndroidTheme
 import com.msg.lecture.component.LectureExcelDownloadBottomSheet
+import com.msg.lecture.component.LectureKakaoMap
 import com.msg.lecture.viewmodel.LectureViewModel
 import com.msg.model.entity.lecture.DetailLectureEntity
 import com.msg.model.enumdata.LectureStatus
@@ -115,6 +116,17 @@ internal fun LectureDetailScreen(
     val isPositiveActionDialogVisible = remember { mutableStateOf(false) }
     val isNegativeDialogVisible = remember { mutableStateOf(false) }
     val isApplicationState = remember { mutableStateOf(false) }
+    val locationX = remember { mutableStateOf(data.locationX) }
+    val locationY = remember { mutableStateOf(data.locationY) }
+    val isLocationLoaded = remember { mutableStateOf(false) }
+
+    LaunchedEffect(data) {
+        if (data.locationX.isNotEmpty() && data.locationY.isNotEmpty()) {
+            locationX.value = data.locationX
+            locationY.value = data.locationY
+            isLocationLoaded.value = true
+        }
+    }
 
     BitgoeulAndroidTheme { colors, typography ->
         Box(
@@ -284,6 +296,40 @@ internal fun LectureDetailScreen(
                     color = colors.G2,
                     style = typography.bodySmall
                 )
+
+                Spacer(modifier = modifier.height(24.dp))
+
+                Text(
+                    text = "강의 장소",
+                    color = colors.BLACK,
+                    style = typography.bodyLarge,
+                )
+
+                Spacer(modifier = modifier.height(16.dp))
+
+                Text(
+                    text = "${data.address}",
+                    color = colors.G2,
+                    style = typography.bodySmall
+                )
+
+                Spacer(modifier = modifier.height(4.dp))
+
+                Text(
+                    text = "${data.locationDetails}",
+                    color = colors.G2,
+                    style = typography.bodySmall
+                )
+
+                Spacer(modifier = modifier.height(4.dp))
+
+                if (isLocationLoaded.value) {
+                    LectureKakaoMap(
+                        modifier = modifier.fillMaxWidth(),
+                        locationX = locationX.value.toDouble(),
+                        locationY = locationY.value.toDouble()
+                    )
+                }
 
                 Spacer(modifier = modifier.height(24.dp))
 

--- a/feature/lecture/src/main/java/com/msg/lecture/LectureDetailScreen.kt
+++ b/feature/lecture/src/main/java/com/msg/lecture/LectureDetailScreen.kt
@@ -24,6 +24,7 @@ import androidx.compose.runtime.remember
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.platform.LocalContext
+import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
 import androidx.hilt.navigation.compose.hiltViewModel
@@ -48,6 +49,7 @@ import com.msg.ui.util.toLocalTimeFormat
 import java.time.LocalDate
 import java.time.LocalDateTime
 import java.time.LocalTime
+import com.msg.design_system.R
 
 @Composable
 internal fun LectureDetailRoute(
@@ -228,7 +230,23 @@ internal fun LectureDetailScreen(
                 ) {
 
                     Text(
-                        text = "${data.semester}",
+                        text = when (data.semester) {
+                            "FIRST_YEAR_FALL_SEMESTER" -> {
+                                stringResource(id = R.string.first_year_second_semester)
+                            }
+                            "SECOND_YEAR_SPRING_SEMESTER" -> {
+                                stringResource(id = R.string.second_year_first_semester)
+                            }
+                            "SECOND_YEAR_FALL_SEMESTER" -> {
+                                stringResource(id = R.string.second_year_second_semester)
+                            }
+                            "THIRD_YEAR_SPRING_SEMESTER" -> {
+                                stringResource(id = R.string.third_year_first_semester)
+                            }
+                            else -> {
+                                "학기 정보 없음 고객센터에 문의 바람."
+                            }
+                        },
                         color = colors.G2,
                         style = typography.labelMedium
                     )

--- a/feature/lecture/src/main/java/com/msg/lecture/LectureDetailScreen.kt
+++ b/feature/lecture/src/main/java/com/msg/lecture/LectureDetailScreen.kt
@@ -462,7 +462,7 @@ private fun LectureDetailScreenPre() {
             name = "컴퓨터 프로그래밍",
             semester = "2021년 1학기",
             credit = 3,
-            createAt = LocalDate.now(),
+            createAt = LocalDateTime.now(),
             lecturer = "홍길동",
             content = "컴퓨터 프로그래밍에 대한 강의입니다.",
             startDate = LocalDateTime.now(),
@@ -481,7 +481,7 @@ private fun LectureDetailScreenPre() {
             isRegistered = false,
             locationX = "",
             locationY = "",
-            address = "",
+            address = "광주 광산구 호남대길 100 호남대학교",
             locationDetails = ""
         ),
         onBackClicked = {},

--- a/feature/lecture/src/main/java/com/msg/lecture/LectureListScreen.kt
+++ b/feature/lecture/src/main/java/com/msg/lecture/LectureListScreen.kt
@@ -66,9 +66,9 @@ internal fun LectureListRoute(
         data = viewModel.lectureList.value,
         onOpenClicked = onOpenClicked,
         onItemClicked = { id ->
-            onItemClicked()
             viewModel.selectedLectureId.value = id
             viewModel.getDetailLecture(id)
+            onItemClicked()
         },
         onFilterChanged = { type ->
             viewModel.lectureList.value = LectureListEntity(

--- a/feature/lecture/src/main/java/com/msg/lecture/component/LectureKakaoMap.kt
+++ b/feature/lecture/src/main/java/com/msg/lecture/component/LectureKakaoMap.kt
@@ -1,0 +1,65 @@
+package com.msg.lecture.component
+
+import androidx.compose.foundation.layout.height
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.remember
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.platform.LocalContext
+import androidx.compose.ui.unit.dp
+import androidx.compose.ui.viewinterop.AndroidView
+import com.kakao.vectormap.KakaoMap
+import com.kakao.vectormap.KakaoMapReadyCallback
+import com.kakao.vectormap.LatLng
+import com.kakao.vectormap.MapLifeCycleCallback
+import com.kakao.vectormap.MapView
+import com.kakao.vectormap.camera.CameraUpdateFactory
+import com.kakao.vectormap.label.LabelOptions
+import com.kakao.vectormap.label.LabelStyle
+import com.kakao.vectormap.label.LabelStyles
+import com.msg.ui.makeToast
+
+@Composable
+fun LectureKakaoMap(
+    modifier: Modifier = Modifier,
+    locationX: Double,
+    locationY: Double,
+) {
+    val context = LocalContext.current
+    val mapView = remember { MapView(context) }
+
+    AndroidView(
+        modifier = modifier.height(200.dp),
+        factory = { context ->
+            mapView.apply {
+                mapView.start(
+                    object : MapLifeCycleCallback() {
+                        override fun onMapDestroy() {
+                            makeToast(context = context, message = "지도를 불러오는데 실패했습니다.")
+                        }
+
+                        override fun onMapError(exception: Exception?) {
+                            makeToast(context = context, message = "지도를 불러오는 중 알 수 없는 에러가 발생했습니다.\n onMapError: $exception")
+                        }
+                    },
+
+                    object : KakaoMapReadyCallback() {
+                        override fun onMapReady(kakaoMap: KakaoMap) {
+                            val cameraUpdate = CameraUpdateFactory.newCenterPosition(LatLng.from(locationY, locationX))
+                            val style = kakaoMap.labelManager?.addLabelStyles(LabelStyles.from(LabelStyle.from(com.msg.design_system.R.drawable.ic_new_bitgoeul)))
+                            val options = LabelOptions.from(LatLng.from(locationY, locationX)).setStyles(style)
+                            val layer = kakaoMap.labelManager?.layer
+
+                            kakaoMap.moveCamera(cameraUpdate)
+                            layer?.addLabel(options)
+                        }
+
+                        override fun getPosition(): LatLng {
+                            return LatLng.from(locationY, locationX)
+                        }
+                    },
+                )
+            }
+        },
+    )
+}
+

--- a/feature/lecture/src/main/java/com/msg/lecture/viewmodel/LectureViewModel.kt
+++ b/feature/lecture/src/main/java/com/msg/lecture/viewmodel/LectureViewModel.kt
@@ -221,7 +221,7 @@ class LectureViewModel @Inject constructor(
             division = "",
             department = "",
             line = "",
-            createAt = LocalDate.now(),
+            createAt = LocalDateTime.now(),
             startDate = LocalDateTime.now(),
             endDate = LocalDateTime.now(),
             lectureDates = listOf(

--- a/feature/lecture/src/main/java/com/msg/lecture/viewmodel/LectureViewModel.kt
+++ b/feature/lecture/src/main/java/com/msg/lecture/viewmodel/LectureViewModel.kt
@@ -571,6 +571,10 @@ class LectureViewModel @Inject constructor(
             }
     }
 
+    internal fun setLectureDetailData(data: DetailLectureEntity) {
+        lectureDetailData.value = data
+    }
+
     private fun saveFileToStorage(
         response: DownloadExcelFileEntity
     ) {

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -48,6 +48,7 @@ retrofitKotlinxSerializableJson = "1.0.0"
 room = "2.5.2"
 kotlin2 = "1.9.10"
 moshi = "1.15.0"
+kakaoMaps = "2.9.5"
 
 [libraries]
 #Define Library
@@ -107,6 +108,7 @@ retrofit-moshi-codegen = { group = "com.squareup.moshi", name = "moshi-kotlin-co
 retrofit-moshi-converter = { group = "com.squareup.retrofit2", name = "converter-moshi", version.ref = "retrofit" }
 room-compiler = { group = "androidx.room", name = "room-compiler", version.ref = "room" }
 room-ktx = { group = "androidx.room", name = "room-ktx", version.ref = "room" }
+kakao-maps = { group = "com.kakao.maps.open", name = "android", version.ref = "kakaoMaps" }
 room-runtime = { group = "androidx.room", name = "room-runtime", version.ref = "room" }
 moshi = { group = "com.squareup.moshi", name = "moshi-kotlin", version.ref = "moshi" }
 

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -13,6 +13,7 @@ dependencyResolutionManagement {
         google()
         mavenCentral()
         maven("https://jitpack.io")
+        maven("https://devrepo.kakao.com/nexus/repository/kakaomap-releases/")
     }
 }
 


### PR DESCRIPTION
## 💡 개요
강의 상세 정보 페이지에 사용자에게 카카오맵을 통해 강의 장소를 보여줘야합니다.
## 📃 작업 내용

https://github.com/user-attachments/assets/777a97f2-6ec2-4c83-97e8-985bf5edb2a8


강의 상세 정보 페이지에 카카오맵 UI를 추가했습니다.
## 🔀 변경사항
기존 LectureDetailResponse에 LectureDates Json 파싱 코드 추가했습니다.
LocalDateTime, LocalDate, LocalTime Json 파싱을 위한 Adapter 추가했습니다.
KakaoMap사용을 위한 MainActivity init 코드 추가했습니다.
LectureDetailResponse의 createAt 필드의 타입을 서버와 같은 LocalDateTime 타입으로 변경했습니다.
LectureViewModel에 LectureDetailResponse set함수 추가
## 🙋‍♂️ 질문사항
제가 잘못 구현한 코드나 더 나은 코드 리팩토링 방안이 있다면 알려주세요.
## 🎸 기타
작업 도중 앱 출시를 위한 임시방편용 코드가 몇몇 존재하는 걸 발견했습니다.
추후 논의 후 컨벤션, 리팩토링 진행 계획을 세워야할 거 같아요.
