### PR TITLE
🔀 :: (#256) - passwordchangescreen state  manage viewmodel

### DIFF
--- a/feature/my-page/src/main/java/com/example/my_page/PasswordChangeScreen.kt
+++ b/feature/my-page/src/main/java/com/example/my_page/PasswordChangeScreen.kt
@@ -14,6 +14,7 @@ import androidx.compose.runtime.Composable
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.focus.FocusManager
 import androidx.compose.ui.input.pointer.pointerInput
@@ -75,8 +76,8 @@ internal fun PasswordChangeScreen(
     onSuccessScreenButtonClicked: () -> Unit,
     onBackClicked: () -> Unit
 ) {
-    val isWrongPassword = remember { mutableStateOf(false) }
-    val isSamePassword = remember { mutableStateOf(true) }
+    val isWrongPassword by remember { mutableStateOf(false) }
+    var isSamePassword by remember { mutableStateOf(true) }
 
     val (isShowSuccessScreen, setIsShowSuccessScreen) = remember { mutableStateOf(false) }
 
@@ -118,7 +119,7 @@ internal fun PasswordChangeScreen(
                         errorText = stringResource(R.string.disagree_password),
                         onValueChange = onCurrentPasswordChange,
                         onLinkClicked = {},
-                        isError = isWrongPassword.value,
+                        isError = isWrongPassword,
                         isLinked = false,
                         isDisabled = false
                     )
@@ -140,10 +141,10 @@ internal fun PasswordChangeScreen(
                         errorText = stringResource(R.string.disagree_password),
                         onValueChange = {
                             onCheckPasswordChange(it)
-                            isSamePassword.value = newPassword == checkPassword
+                            isSamePassword = newPassword == checkPassword
                         },
                         onLinkClicked = {},
-                        isError = !isSamePassword.value,
+                        isError = !isSamePassword,
                         isLinked = false,
                         isDisabled = false
                     )

--- a/feature/my-page/src/main/java/com/example/my_page/PasswordChangeScreen.kt
+++ b/feature/my-page/src/main/java/com/example/my_page/PasswordChangeScreen.kt
@@ -40,9 +40,9 @@ internal fun PasswordChangeRoute(
     onBackClicked: () -> Unit,
     viewModel: MyPageViewModel = hiltViewModel()
 ) {
-    val currentPassword by viewModel.currentPassword.collectAsStateWithLifecycle()
-    val newPassword by viewModel.newPassword.collectAsStateWithLifecycle()
-    val checkPassword by viewModel.checkPassword.collectAsStateWithLifecycle()
+    val isCurrentPassword by viewModel.currentPassword.collectAsStateWithLifecycle()
+    val isNewPassword by viewModel.newPassword.collectAsStateWithLifecycle()
+    val isCheckPassword by viewModel.checkPassword.collectAsStateWithLifecycle()
 
     PasswordChangeScreen(
         onPasswordChangeClicked = { currentPassword, newPassword ->
@@ -53,9 +53,9 @@ internal fun PasswordChangeRoute(
         },
         onSuccessScreenButtonClicked = onSuccessScreenButtonClicked,
         onBackClicked = onBackClicked,
-        currentPassword = currentPassword,
-        newPassword = newPassword,
-        checkPassword = checkPassword,
+        currentPassword = isCurrentPassword,
+        newPassword = isNewPassword,
+        checkPassword = isCheckPassword,
         onNewPasswordChange = viewModel::onNewPasswordChange,
         onCurrentPasswordChange = viewModel::onCurrentPasswordChange,
         onCheckPasswordChange = viewModel::onCheckPasswordChange

--- a/feature/my-page/src/main/java/com/example/my_page/PasswordChangeScreen.kt
+++ b/feature/my-page/src/main/java/com/example/my_page/PasswordChangeScreen.kt
@@ -11,6 +11,7 @@ import androidx.compose.foundation.layout.padding
 import androidx.compose.material3.Surface
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
 import androidx.compose.ui.Modifier
@@ -21,6 +22,7 @@ import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
 import androidx.hilt.navigation.compose.hiltViewModel
+import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import com.example.my_page.viewmodel.MyPageViewModel
 import com.msg.design_system.component.button.BitgoeulButton
 import com.msg.design_system.component.icon.GoBackIcon
@@ -37,6 +39,9 @@ internal fun PasswordChangeRoute(
     onBackClicked: () -> Unit,
     viewModel: MyPageViewModel = hiltViewModel()
 ) {
+    val currentPassword by viewModel.currentPassword.collectAsStateWithLifecycle()
+    val newPassword by viewModel.newPassword.collectAsStateWithLifecycle()
+    val checkPassword by viewModel.checkPassword.collectAsStateWithLifecycle()
 
     PasswordChangeScreen(
         onPasswordChangeClicked = { currentPassword, newPassword ->
@@ -46,22 +51,30 @@ internal fun PasswordChangeRoute(
             )
         },
         onSuccessScreenButtonClicked = onSuccessScreenButtonClicked,
-        onBackClicked = onBackClicked
+        onBackClicked = onBackClicked,
+        currentPassword = currentPassword,
+        newPassword = newPassword,
+        checkPassword = checkPassword,
+        onNewPasswordChange = viewModel::onNewPasswordChange,
+        onCurrentPasswordChange = viewModel::onCurrentPasswordChange,
+        onCheckPasswordChange = viewModel::onCheckPasswordChange
     )
 }
 
 @Composable
 internal fun PasswordChangeScreen(
     modifier: Modifier = Modifier,
+    currentPassword: String,
+    newPassword: String,
+    checkPassword: String,
+    onNewPasswordChange: (String) -> Unit,
+    onCurrentPasswordChange: (String) -> Unit,
+    onCheckPasswordChange: (String) -> Unit,
     focusManager: FocusManager = LocalFocusManager.current,
     onPasswordChangeClicked: (currentPassword: String, newPassword: String) -> Unit,
     onSuccessScreenButtonClicked: () -> Unit,
     onBackClicked: () -> Unit
 ) {
-    val (isCurrentPassword, setIsCurrentPassword) = remember { mutableStateOf("") }
-    val (isNewPassword, setIsNewPassword) = remember { mutableStateOf("") }
-    val (isCheckPassword, setIsCheckPassword) = remember { mutableStateOf("") }
-
     val isWrongPassword = remember { mutableStateOf(false) }
     val isSamePassword = remember { mutableStateOf(true) }
 
@@ -103,7 +116,7 @@ internal fun PasswordChangeScreen(
                         modifier = modifier.fillMaxWidth(),
                         placeholder = stringResource(R.string.current_password),
                         errorText = stringResource(R.string.disagree_password),
-                        onValueChange = setIsCurrentPassword,
+                        onValueChange = onCurrentPasswordChange,
                         onLinkClicked = {},
                         isError = isWrongPassword.value,
                         isLinked = false,
@@ -114,9 +127,9 @@ internal fun PasswordChangeScreen(
                         modifier = modifier.fillMaxWidth(),
                         placeholder = stringResource(R.string.new_password),
                         errorText = "비밀번호는 8~24 영어 + 숫자  + 특수문자 로 해주세요",
-                        onValueChange = setIsNewPassword,
+                        onValueChange = onNewPasswordChange,
                         onLinkClicked = {},
-                        isError = isNewPassword.checkPasswordRegex(),
+                        isError = newPassword.checkPasswordRegex(),
                         isLinked = false,
                         isDisabled = false
                     )
@@ -126,8 +139,8 @@ internal fun PasswordChangeScreen(
                         placeholder = stringResource(R.string.check_new_password),
                         errorText = stringResource(R.string.disagree_password),
                         onValueChange = {
-                            setIsCheckPassword(it)
-                            isSamePassword.value = isNewPassword == isCheckPassword
+                            onCheckPasswordChange(it)
+                            isSamePassword.value = newPassword == checkPassword
                         },
                         onLinkClicked = {},
                         isError = !isSamePassword.value,
@@ -143,7 +156,7 @@ internal fun PasswordChangeScreen(
                             .padding(horizontal = 28.dp),
                         text = stringResource(R.string.change)
                     ) {
-                        onPasswordChangeClicked(isCurrentPassword, isNewPassword)
+                        onPasswordChangeClicked(currentPassword, newPassword)
                         setIsShowSuccessScreen(true)
                     }
                     Spacer(modifier = modifier.height(56.dp))
@@ -170,6 +183,12 @@ fun PasswordChangeScreenPre() {
         onSuccessScreenButtonClicked = {},
         onPasswordChangeClicked = { _, _ -> },
         onBackClicked = {},
-        focusManager = LocalFocusManager.current
+        focusManager = LocalFocusManager.current,
+        currentPassword = "",
+        onCurrentPasswordChange = {},
+        newPassword = "",
+        onNewPasswordChange = {},
+        checkPassword = "",
+        onCheckPasswordChange = {}
     )
 }

--- a/feature/my-page/src/main/java/com/example/my_page/viewmodel/MyPageViewModel.kt
+++ b/feature/my-page/src/main/java/com/example/my_page/viewmodel/MyPageViewModel.kt
@@ -2,6 +2,7 @@ package com.example.my_page.viewmodel
 
 import com.msg.model.enumdata.Authority
 import androidx.compose.runtime.mutableStateOf
+import androidx.lifecycle.SavedStateHandle
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
 import com.msg.common.errorhandling.errorHandling
@@ -24,8 +25,15 @@ class MyPageViewModel @Inject constructor(
     private val getMyPageUseCase: GetMyPageUseCase,
     private val withdrawUseCase: WithdrawUseCase,
     private val logoutUseCase: LogoutUseCase,
-    private val changePasswordUseCase: ChangePasswordUseCase
+    private val changePasswordUseCase: ChangePasswordUseCase,
+    private val savedStateHandle: SavedStateHandle
 ) : ViewModel() {
+
+    companion object {
+        private const val CURRENT_PASSWORD = "currentPassword"
+        private const val NEW_PASSWORD = "newPassword"
+        private const val CHECK_PASSWORD = "checkPassword"
+    }
 
     private val _getMyPageResponse = MutableStateFlow<Event<GetMyPageEntity>>(Event.Loading)
     val getMyPageResponse = _getMyPageResponse.asStateFlow()
@@ -49,6 +57,12 @@ class MyPageViewModel @Inject constructor(
         )
     )
         private set
+
+    internal var currentPassword = savedStateHandle.getStateFlow(key = CURRENT_PASSWORD, initialValue = "")
+
+    internal var newPassword = savedStateHandle.getStateFlow(key = NEW_PASSWORD, initialValue = "")
+
+    internal var checkPassword = savedStateHandle.getStateFlow(key = CHECK_PASSWORD, initialValue = "")
 
     internal fun inquiryMyPage() = viewModelScope.launch {
         getMyPageUseCase().onSuccess {
@@ -105,4 +119,10 @@ class MyPageViewModel @Inject constructor(
             _getChangePasswordResponse.value = error.errorHandling()
         }
     }
+
+    internal fun onCurrentPasswordChange(value: String) { savedStateHandle[CURRENT_PASSWORD] = value }
+
+    internal fun onNewPasswordChange(value: String) { savedStateHandle[NEW_PASSWORD] = value }
+
+    internal fun onCheckPasswordChange(value: String) { savedStateHandle[CHECK_PASSWORD] = value }
 }


### PR DESCRIPTION
## 💡 개요
- PasswordChangeScreen에서 상태를 SavedStateHandle을 사용해서 viewModel에서 관리할 수 있도록 합니다
## 📃 작업내용
- 상태 관리를 viewModel에서 할 수 있도록 변경했습니다
## 🔀 변경사항
- refactor MyPagedViewModel
- refactor PasswordChangeScreen
