### PR TITLE
🔀 :: (#258) - certification module refactor

### DIFF
--- a/core/design-system/src/main/res/values/strings.xml
+++ b/core/design-system/src/main/res/values/strings.xml
@@ -82,4 +82,5 @@
     <string name="professor_in_charge_placeholder">학과 이름으로 검색...</string>
     <string name="division_placeholder">강의 구분 검색...</string>
     <string name="entire">전체</string>
+    <string name="student_information">학생정보</string>
 </resources>

--- a/feature/certification/src/main/java/com/msg/certification/AddCertificationScreen.kt
+++ b/feature/certification/src/main/java/com/msg/certification/AddCertificationScreen.kt
@@ -11,6 +11,7 @@ import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.padding
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
 import androidx.compose.ui.Modifier
@@ -20,6 +21,7 @@ import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.platform.LocalFocusManager
 import androidx.compose.ui.unit.dp
 import androidx.hilt.navigation.compose.hiltViewModel
+import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import com.msg.certification.component.AddAcquisitionDateSection
 import com.msg.certification.component.AddCertificationSection
 import com.msg.certification.viewmodel.CertificationViewModel
@@ -37,10 +39,14 @@ internal fun AddCertificationScreenRoute(
     onBackClicked: () -> Unit,
     onAddClicked: () -> Unit
 ) {
+    val selectedTitle by viewModel.selectedTitle.collectAsStateWithLifecycle()
+    val selectedDate by viewModel.selectedDate.collectAsStateWithLifecycle()
 
     AddCertificationScreen(
-        selectedName = viewModel.selectedTitle.value,
-        selectedDate = viewModel.selectedDate.value,
+        selectedName = selectedTitle,
+        selectedDate = selectedDate,
+        onSelectedDateChange = viewModel::onSelectedDateChange,
+        onSelectedNameChange = viewModel::onSelectedTitleChange,
         onBackClicked = {
             onBackClicked()
         },
@@ -59,12 +65,11 @@ internal fun AddCertificationScreen(
     focusManager: FocusManager = LocalFocusManager.current,
     selectedName: String,
     selectedDate: LocalDate?,
+    onSelectedNameChange: (String) -> Unit,
+    onSelectedDateChange: (LocalDate?) -> Unit,
     onBackClicked: () -> Unit,
     onAddClicked: (name: String, acquisitionDate: LocalDate) -> Unit
 ) {
-    val name = remember { mutableStateOf(selectedName) }
-    val date = remember { mutableStateOf(selectedDate) }
-
     BitgoeulAndroidTheme { colors, _ ->
         Box(
             modifier = modifier
@@ -93,30 +98,24 @@ internal fun AddCertificationScreen(
                     onBackClicked = onBackClicked
                 )
                 AddCertificationSection(
-                    onValueChange = {
-                        name.value = it
-                    },
-                    onButtonClicked = {
-                        name.value = ""
-                    }
+                    onValueChange = onSelectedNameChange,
+                    onButtonClicked = { onSelectedNameChange("") }
                 )
                 AddAcquisitionDateSection(
-                    onDatePickerQuit = {
-                        date.value = it
-                    },
-                    acquisitionDate = date.value?.toKoreanFormat() ?: ""
+                    onDatePickerQuit = onSelectedDateChange,
+                    acquisitionDate = selectedDate?.toKoreanFormat() ?: ""
                 )
                 Spacer(modifier = modifier.weight(1f))
                 BitgoeulButton(
                     modifier = modifier.fillMaxWidth(),
                     text = "자격증 등록",
                     onClicked = {
-                        if (name.value.isBlank()) {
+                        if (selectedName.isBlank()) {
                             makeToast(context, "자격증 이름을 입력해주세요")
-                        } else if (date.value == null) {
+                        } else if (selectedDate == null) {
                             makeToast(context, "취득일을 입력해주세요")
                         } else {
-                            onAddClicked(name.value, date.value!!)
+                            onAddClicked(selectedName, selectedDate)
                         }
                     }
                 )
@@ -134,6 +133,8 @@ fun AddCertificationScreenPre() {
         onAddClicked = { _, _ -> },
         selectedName = "",
         selectedDate = null,
-        focusManager = LocalFocusManager.current
+        focusManager = LocalFocusManager.current,
+        onSelectedNameChange = {},
+        onSelectedDateChange = {}
     )
 }

--- a/feature/certification/src/main/java/com/msg/certification/AddCertificationScreen.kt
+++ b/feature/certification/src/main/java/com/msg/certification/AddCertificationScreen.kt
@@ -40,16 +40,12 @@ internal fun AddCertificationScreenRoute(
     onAddClicked: () -> Unit
 ) {
     val selectedTitle by viewModel.selectedTitle.collectAsStateWithLifecycle()
-    val selectedDate by viewModel.selectedDate.collectAsStateWithLifecycle()
 
     AddCertificationScreen(
         selectedName = selectedTitle,
-        selectedDate = selectedDate,
-        onSelectedDateChange = viewModel::onSelectedDateChange,
+        selectedDate = viewModel.selectedDate.value,
         onSelectedNameChange = viewModel::onSelectedTitleChange,
-        onBackClicked = {
-            onBackClicked()
-        },
+        onBackClicked = { onBackClicked() },
         onAddClicked = { name, acquisitionDate ->
             viewModel.selectedCertificationId.value?.let {
                 viewModel.editCertification(name = name, acquisitionDate = acquisitionDate)
@@ -64,12 +60,13 @@ internal fun AddCertificationScreen(
     modifier: Modifier = Modifier,
     focusManager: FocusManager = LocalFocusManager.current,
     selectedName: String,
-    selectedDate: LocalDate?,
     onSelectedNameChange: (String) -> Unit,
-    onSelectedDateChange: (LocalDate?) -> Unit,
     onBackClicked: () -> Unit,
+    selectedDate: LocalDate?,
     onAddClicked: (name: String, acquisitionDate: LocalDate) -> Unit
 ) {
+    val (isDate, setIsDate) = remember { mutableStateOf(selectedDate) }
+
     BitgoeulAndroidTheme { colors, _ ->
         Box(
             modifier = modifier
@@ -102,8 +99,8 @@ internal fun AddCertificationScreen(
                     onButtonClicked = { onSelectedNameChange("") }
                 )
                 AddAcquisitionDateSection(
-                    onDatePickerQuit = onSelectedDateChange,
-                    acquisitionDate = selectedDate?.toKoreanFormat() ?: ""
+                    onDatePickerQuit = setIsDate,
+                    acquisitionDate = isDate?.toKoreanFormat() ?: ""
                 )
                 Spacer(modifier = modifier.weight(1f))
                 BitgoeulButton(
@@ -112,10 +109,10 @@ internal fun AddCertificationScreen(
                     onClicked = {
                         if (selectedName.isBlank()) {
                             makeToast(context, "자격증 이름을 입력해주세요")
-                        } else if (selectedDate == null) {
+                        } else if (isDate == null) {
                             makeToast(context, "취득일을 입력해주세요")
                         } else {
-                            onAddClicked(selectedName, selectedDate)
+                            onAddClicked(selectedName, isDate)
                         }
                     }
                 )
@@ -135,6 +132,5 @@ fun AddCertificationScreenPre() {
         selectedDate = null,
         focusManager = LocalFocusManager.current,
         onSelectedNameChange = {},
-        onSelectedDateChange = {}
     )
 }

--- a/feature/certification/src/main/java/com/msg/certification/AddCertificationScreen.kt
+++ b/feature/certification/src/main/java/com/msg/certification/AddCertificationScreen.kt
@@ -45,7 +45,7 @@ internal fun AddCertificationScreenRoute(
         selectedName = selectedTitle,
         selectedDate = viewModel.selectedDate.value,
         onSelectedNameChange = viewModel::onSelectedTitleChange,
-        onBackClicked = { onBackClicked() },
+        onBackClicked = onBackClicked,
         onAddClicked = { name, acquisitionDate ->
             viewModel.selectedCertificationId.value?.let {
                 viewModel.editCertification(name = name, acquisitionDate = acquisitionDate)

--- a/feature/certification/src/main/java/com/msg/certification/CertificationScreen.kt
+++ b/feature/certification/src/main/java/com/msg/certification/CertificationScreen.kt
@@ -35,6 +35,7 @@ import com.msg.model.entity.club.StudentBelongClubEntity
 import com.msg.model.entity.lecture.GetLectureSignUpHistoryEntity
 import com.msg.model.entity.lecture.SignUpLectures
 import com.msg.ui.DevicePreviews
+import com.msg.ui.util.toDotFormat
 import java.time.LocalDate
 import java.util.UUID
 
@@ -77,7 +78,7 @@ internal fun CertificationScreenRoute(
         onEditClicked = { id, title, date ->
             viewModel.selectedCertificationId.value = id
             viewModel.onSelectedTitleChange(title)
-            viewModel.onSelectedDateChange(date)
+            viewModel.selectedDate.value = date
             onEditClicked()
         },
         onPlusClicked = onEditClicked,

--- a/feature/certification/src/main/java/com/msg/certification/CertificationScreen.kt
+++ b/feature/certification/src/main/java/com/msg/certification/CertificationScreen.kt
@@ -35,7 +35,6 @@ import com.msg.model.entity.club.StudentBelongClubEntity
 import com.msg.model.entity.lecture.GetLectureSignUpHistoryEntity
 import com.msg.model.entity.lecture.SignUpLectures
 import com.msg.ui.DevicePreviews
-import com.msg.ui.util.toDotFormat
 import java.time.LocalDate
 import java.util.UUID
 

--- a/feature/certification/src/main/java/com/msg/certification/CertificationScreen.kt
+++ b/feature/certification/src/main/java/com/msg/certification/CertificationScreen.kt
@@ -76,8 +76,8 @@ internal fun CertificationScreenRoute(
         onHumanIconClicked = onHumanIconClicked,
         onEditClicked = { id, title, date ->
             viewModel.selectedCertificationId.value = id
-            viewModel.selectedTitle.value = title
-            viewModel.selectedDate.value = date
+            viewModel.onSelectedTitleChange(title)
+            viewModel.onSelectedDateChange(date)
             onEditClicked()
         },
         onPlusClicked = onEditClicked,

--- a/feature/certification/src/main/java/com/msg/certification/CertificationScreen.kt
+++ b/feature/certification/src/main/java/com/msg/certification/CertificationScreen.kt
@@ -19,6 +19,7 @@ import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.platform.LocalContext
+import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.unit.dp
 import androidx.hilt.navigation.compose.hiltViewModel
 import com.msg.certification.component.CertificationSection
@@ -26,6 +27,7 @@ import com.msg.certification.component.FinishedLectureSection
 import com.msg.certification.component.StudentInfoSection
 import com.msg.common.event.Event
 import com.msg.certification.viewmodel.CertificationViewModel
+import com.msg.design_system.R
 import com.msg.design_system.component.icon.HumanIcon
 import com.msg.design_system.theme.BitgoeulAndroidTheme
 import com.msg.model.entity.certification.CertificationListEntity
@@ -157,7 +159,7 @@ internal fun CertificationScreen(
                     verticalAlignment = Alignment.CenterVertically
                 ) {
                     Text(
-                        text = "학생정보",
+                        text = stringResource(R.string.student_information),
                         style = typography.titleMedium,
                         color = colors.BLACK
                     )

--- a/feature/certification/src/main/java/com/msg/certification/viewmodel/CertificationViewModel.kt
+++ b/feature/certification/src/main/java/com/msg/certification/viewmodel/CertificationViewModel.kt
@@ -35,6 +35,10 @@ class CertificationViewModel @Inject constructor(
     private val getAuthorityUseCase: GetAuthorityUseCase,
     private val savedStateHandle: SavedStateHandle
 ) : ViewModel() {
+    companion object {
+        private const val SELECTED_TITLE = "selectedTitle"
+        private const val SELECTED_DATE = "selectedDate"
+    }
 
     private val role = getRole().toString()
 
@@ -62,11 +66,9 @@ class CertificationViewModel @Inject constructor(
     var selectedCertificationId = mutableStateOf<UUID?>(null)
         private set
 
-    var selectedTitle = mutableStateOf("")
-        private set
+    internal var selectedTitle = savedStateHandle.getStateFlow(key = SELECTED_TITLE, initialValue = "")
 
-    var selectedDate = mutableStateOf<LocalDate?>(null)
-        private set
+    internal var selectedDate = savedStateHandle.getStateFlow(key = SELECTED_DATE, initialValue = null as LocalDate?)
 
     var certificationList = mutableStateListOf<CertificationListEntity>()
         private set
@@ -191,4 +193,8 @@ class CertificationViewModel @Inject constructor(
     private fun getRole() = viewModelScope.launch {
         getAuthorityUseCase()
     }
+
+    internal fun onSelectedTitleChange(value: String) { savedStateHandle[SELECTED_TITLE] = value }
+
+    internal fun onSelectedDateChange(value: LocalDate?) { savedStateHandle[SELECTED_DATE] = value }
 }

--- a/feature/certification/src/main/java/com/msg/certification/viewmodel/CertificationViewModel.kt
+++ b/feature/certification/src/main/java/com/msg/certification/viewmodel/CertificationViewModel.kt
@@ -22,7 +22,6 @@ import kotlinx.coroutines.flow.asStateFlow
 import kotlinx.coroutines.flow.catch
 import kotlinx.coroutines.launch
 import java.time.LocalDate
-import java.time.format.DateTimeFormatter
 import java.util.UUID
 import javax.inject.Inject
 

--- a/feature/certification/src/main/java/com/msg/certification/viewmodel/CertificationViewModel.kt
+++ b/feature/certification/src/main/java/com/msg/certification/viewmodel/CertificationViewModel.kt
@@ -22,6 +22,7 @@ import kotlinx.coroutines.flow.asStateFlow
 import kotlinx.coroutines.flow.catch
 import kotlinx.coroutines.launch
 import java.time.LocalDate
+import java.time.format.DateTimeFormatter
 import java.util.UUID
 import javax.inject.Inject
 
@@ -37,7 +38,6 @@ class CertificationViewModel @Inject constructor(
 ) : ViewModel() {
     companion object {
         private const val SELECTED_TITLE = "selectedTitle"
-        private const val SELECTED_DATE = "selectedDate"
     }
 
     private val role = getRole().toString()
@@ -68,7 +68,8 @@ class CertificationViewModel @Inject constructor(
 
     internal var selectedTitle = savedStateHandle.getStateFlow(key = SELECTED_TITLE, initialValue = "")
 
-    internal var selectedDate = savedStateHandle.getStateFlow(key = SELECTED_DATE, initialValue = null as LocalDate?)
+    var selectedDate = mutableStateOf<LocalDate?>(null)
+        private set
 
     var certificationList = mutableStateListOf<CertificationListEntity>()
         private set
@@ -195,6 +196,4 @@ class CertificationViewModel @Inject constructor(
     }
 
     internal fun onSelectedTitleChange(value: String) { savedStateHandle[SELECTED_TITLE] = value }
-
-    internal fun onSelectedDateChange(value: LocalDate?) { savedStateHandle[SELECTED_DATE] = value }
 }


### PR DESCRIPTION
## 💡 개요
- Certification 모듈이 리팩토링이 필요합니다
## 📃 작업내용
- Certification 모듈을 리팩토링 했습니다
   - 컴표저블 안에서 remember를 사용하여 상태를 관리하는 것을 viewModel에서 SavedStateHandle로 관리할 수 있도록 수정하였습니다
   - 상태 호이스팅을 사용했습니다
   - 구조 분해 선언을 사용해서 remember를 사용할 수 있도록 수정했습니다
   - 재사용 가능성이 있는 문자를 strings.xml 파일에 넣어 stringResource로 읽어올 수 있도록 수정하였습니다
## 🔀 변경사항
- refactor CertificationViewModel
- refactor AddCertificationScreen
- refactor CertificationScreen