### PR TITLE
🔀 :: (#262) - refactor email module

### DIFF
--- a/core/design-system/src/main/java/com/msg/design_system/util/checkRegex.kt
+++ b/core/design-system/src/main/java/com/msg/design_system/util/checkRegex.kt
@@ -1,11 +1,5 @@
 package com.msg.design_system.util
 
-fun String.checkEmailRegex(): Boolean {
-    val emailRegex = "^[A-Za-z0-9+_.-]+@[A-Za-z0-9.-]+\$"
-    return this.matches(emailRegex.toRegex())
-}
+fun String.checkEmailRegex(): Boolean = this.matches("^[A-Za-z0-9+_.-]+@[A-Za-z0-9.-]+\$".toRegex())
 
-fun String.checkPasswordRegex(): Boolean {
-    val passwordRegex = "^(?=.*[0-9])(?=.*[A-Za-z])(?=.*[@#$%^&+=!?.])(?=\\S+$).{8,24}.$"
-    return this.matches(passwordRegex.toRegex())
-}
+fun String.checkPasswordRegex(): Boolean = this.matches("^(?=.*[0-9])(?=.*[^A-Za-z0-9]).{8,}$".toRegex())

--- a/feature/email/src/main/java/com/bitgoeul/email/EmailSendInformScreen.kt
+++ b/feature/email/src/main/java/com/bitgoeul/email/EmailSendInformScreen.kt
@@ -132,7 +132,6 @@ internal fun EmailSendInformScreen(
                 Spacer(modifier = modifier.weight(1f))
 
             }
-
         }
     }
 }

--- a/feature/email/src/main/java/com/bitgoeul/email/EmailSendInformScreen.kt
+++ b/feature/email/src/main/java/com/bitgoeul/email/EmailSendInformScreen.kt
@@ -12,6 +12,7 @@ import androidx.compose.material3.Surface
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.DisposableEffect
+import androidx.compose.runtime.getValue
 import androidx.compose.runtime.rememberCoroutineScope
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
@@ -21,6 +22,7 @@ import androidx.compose.ui.unit.dp
 import androidx.hilt.navigation.compose.hiltViewModel
 import androidx.lifecycle.DefaultLifecycleObserver
 import androidx.lifecycle.LifecycleOwner
+import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import com.bitgoeul.email.viewmodel.EmailViewModel
 import com.msg.common.event.Event
 import com.msg.design_system.R
@@ -36,6 +38,8 @@ internal fun EmailSendInformRoute(
     onMoveNewPasswordClicked: () -> Unit,
     viewModel: EmailViewModel = hiltViewModel(LocalContext.current as ComponentActivity)
 ) {
+    val emailText by viewModel.email.collectAsStateWithLifecycle()
+
     val context = LocalContext.current
     val activity = LocalContext.current as ComponentActivity
     val coroutineScope = rememberCoroutineScope()
@@ -68,7 +72,7 @@ internal fun EmailSendInformRoute(
 
     EmailSendInformScreen(
         onBackClicked = onBackClicked,
-        emailText = viewModel.email.value
+        emailText = emailText
     )
 }
 

--- a/feature/email/src/main/java/com/bitgoeul/email/InputEmailScreen.kt
+++ b/feature/email/src/main/java/com/bitgoeul/email/InputEmailScreen.kt
@@ -13,6 +13,7 @@ import androidx.compose.material3.Surface
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.CompositionLocalProvider
+import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
 import androidx.compose.ui.Modifier
@@ -23,6 +24,7 @@ import androidx.compose.ui.platform.LocalFocusManager
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.unit.dp
 import androidx.hilt.navigation.compose.hiltViewModel
+import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import com.bitgoeul.email.viewmodel.EmailViewModel
 import com.msg.design_system.R
 import com.msg.design_system.component.button.BitgoeulButton
@@ -38,11 +40,14 @@ internal fun InputEmailRoute(
     onNextClicked: () -> Unit,
     viewModel: EmailViewModel = hiltViewModel(LocalContext.current as ComponentActivity)
 ) {
+    val email by viewModel.email.collectAsStateWithLifecycle()
 
     InputEmailScreen(
+        email = email,
+        onEmailChange = viewModel::onEmailChange,
         onBackClicked = onBackClicked,
         onNextClicked = { email ->
-            viewModel.email.value = email
+            viewModel.onEmailChange(email)
             viewModel.sendLinkToEmail()
             onNextClicked()
         }
@@ -52,12 +57,12 @@ internal fun InputEmailRoute(
 @Composable
 internal fun InputEmailScreen(
     modifier: Modifier = Modifier,
+    email: String,
+    onEmailChange: (String) -> Unit,
     focusManager: FocusManager = LocalFocusManager.current,
     onBackClicked: () -> Unit,
     onNextClicked: (String) -> Unit,
 ) {
-    val email = remember { mutableStateOf("") }
-
     BitgoeulAndroidTheme { color, typography ->
         Surface {
             Column(
@@ -98,9 +103,7 @@ internal fun InputEmailScreen(
 
                 DefaultTextField(
                     modifier = modifier.fillMaxWidth(),
-                    onValueChange = { inputEmail ->
-                        email.value = inputEmail
-                    },
+                    onValueChange = onEmailChange,
                     errorText = "",
                     isDisabled = false,
                     isError = false,
@@ -118,9 +121,9 @@ internal fun InputEmailScreen(
                         .padding(bottom = 14.dp)
                         .fillMaxWidth()
                         .height(52.dp),
-                    state = if (email.value.isNotEmpty()) ButtonState.Enable else ButtonState.Disable,
+                    state = if (email.isNotEmpty()) ButtonState.Enable else ButtonState.Disable,
                     onClicked = {
-                        onNextClicked(email.value)
+                        onNextClicked(email)
                     }
                 )
             }

--- a/feature/email/src/main/java/com/bitgoeul/email/InputEmailScreen.kt
+++ b/feature/email/src/main/java/com/bitgoeul/email/InputEmailScreen.kt
@@ -116,15 +116,13 @@ internal fun InputEmailScreen(
                 Spacer(modifier = modifier.weight(1f))
 
                 BitgoeulButton(
-                    text = "다음으로",
-                    modifier = Modifier
+                    modifier = modifier
                         .padding(bottom = 14.dp)
                         .fillMaxWidth()
                         .height(52.dp),
+                    text = "다음으로",
                     state = if (email.isNotEmpty()) ButtonState.Enable else ButtonState.Disable,
-                    onClicked = {
-                        onNextClicked(email)
-                    }
+                    onClicked = { onNextClicked(email) }
                 )
             }
         }

--- a/feature/email/src/main/java/com/bitgoeul/email/InputEmailScreen.kt
+++ b/feature/email/src/main/java/com/bitgoeul/email/InputEmailScreen.kt
@@ -40,10 +40,10 @@ internal fun InputEmailRoute(
     onNextClicked: () -> Unit,
     viewModel: EmailViewModel = hiltViewModel(LocalContext.current as ComponentActivity)
 ) {
-    val email by viewModel.email.collectAsStateWithLifecycle()
+    val isEmail by viewModel.email.collectAsStateWithLifecycle()
 
     InputEmailScreen(
-        email = email,
+        email = isEmail,
         onEmailChange = viewModel::onEmailChange,
         onBackClicked = onBackClicked,
         onNextClicked = { email ->

--- a/feature/email/src/main/java/com/bitgoeul/email/InputEmailScreen.kt
+++ b/feature/email/src/main/java/com/bitgoeul/email/InputEmailScreen.kt
@@ -38,10 +38,8 @@ internal fun InputEmailRoute(
     onNextClicked: () -> Unit,
     viewModel: EmailViewModel = hiltViewModel(LocalContext.current as ComponentActivity)
 ) {
-    val focusManager = LocalFocusManager.current
 
     InputEmailScreen(
-        focusManager = focusManager,
         onBackClicked = onBackClicked,
         onNextClicked = { email ->
             viewModel.email.value = email
@@ -54,79 +52,77 @@ internal fun InputEmailRoute(
 @Composable
 internal fun InputEmailScreen(
     modifier: Modifier = Modifier,
-    focusManager: FocusManager,
+    focusManager: FocusManager = LocalFocusManager.current,
     onBackClicked: () -> Unit,
     onNextClicked: (String) -> Unit,
 ) {
     val email = remember { mutableStateOf("") }
 
-    CompositionLocalProvider(LocalFocusManager provides focusManager) {
-        BitgoeulAndroidTheme { color, typography ->
-            Surface {
-                Column(
-                    modifier = modifier
-                        .background(color = color.WHITE)
-                        .padding(horizontal = 28.dp)
-                        .fillMaxSize()
-                        .pointerInput(Unit) {
-                            detectTapGestures {
-                                focusManager.clearFocus()
-                            }
+    BitgoeulAndroidTheme { color, typography ->
+        Surface {
+            Column(
+                modifier = modifier
+                    .background(color = color.WHITE)
+                    .padding(horizontal = 28.dp)
+                    .fillMaxSize()
+                    .pointerInput(Unit) {
+                        detectTapGestures {
+                            focusManager.clearFocus()
                         }
-                ) {
-                    Spacer(modifier = modifier.height(20.dp))
-
-                    GoBackTopBar(
-                        icon = { GoBackIcon() },
-                        text = stringResource(id = R.string.go_back)
-                    ) {
-                        onBackClicked()
                     }
+            ) {
+                Spacer(modifier = modifier.height(20.dp))
 
-                    Spacer(modifier = modifier.height(16.dp))
-
-                    Text(
-                        text = stringResource(id = R.string.find_password),
-                        style = typography.titleLarge,
-                        color = color.BLACK
-                    )
-
-                    Text(
-                        text = stringResource(id = R.string.email_authentication_process),
-                        style = typography.bodySmall,
-                        color = color.G2
-                    )
-
-                    Spacer(modifier = modifier.height(32.dp))
-
-                    DefaultTextField(
-                        modifier = modifier.fillMaxWidth(),
-                        onValueChange = { inputEmail ->
-                            email.value = inputEmail
-                        },
-                        errorText = "",
-                        isDisabled = false,
-                        isError = false,
-                        isLinked = false,
-                        isReverseTrailingIcon = false,
-                        onButtonClicked = {},
-                        placeholder = stringResource(id = R.string.email)
-                    )
-
-                    Spacer(modifier = modifier.weight(1f))
-
-                    BitgoeulButton(
-                        text = "다음으로",
-                        modifier = Modifier
-                            .padding(bottom = 14.dp)
-                            .fillMaxWidth()
-                            .height(52.dp),
-                        state = if (email.value.isNotEmpty()) ButtonState.Enable else ButtonState.Disable,
-                        onClicked = {
-                            onNextClicked(email.value)
-                        }
-                    )
+                GoBackTopBar(
+                    icon = { GoBackIcon() },
+                    text = stringResource(id = R.string.go_back)
+                ) {
+                    onBackClicked()
                 }
+
+                Spacer(modifier = modifier.height(16.dp))
+
+                Text(
+                    text = stringResource(id = R.string.find_password),
+                    style = typography.titleLarge,
+                    color = color.BLACK
+                )
+
+                Text(
+                    text = stringResource(id = R.string.email_authentication_process),
+                    style = typography.bodySmall,
+                    color = color.G2
+                )
+
+                Spacer(modifier = modifier.height(32.dp))
+
+                DefaultTextField(
+                    modifier = modifier.fillMaxWidth(),
+                    onValueChange = { inputEmail ->
+                        email.value = inputEmail
+                    },
+                    errorText = "",
+                    isDisabled = false,
+                    isError = false,
+                    isLinked = false,
+                    isReverseTrailingIcon = false,
+                    onButtonClicked = {},
+                    placeholder = stringResource(id = R.string.email)
+                )
+
+                Spacer(modifier = modifier.weight(1f))
+
+                BitgoeulButton(
+                    text = "다음으로",
+                    modifier = Modifier
+                        .padding(bottom = 14.dp)
+                        .fillMaxWidth()
+                        .height(52.dp),
+                    state = if (email.value.isNotEmpty()) ButtonState.Enable else ButtonState.Disable,
+                    onClicked = {
+                        onNextClicked(email.value)
+                    }
+                )
             }
         }
     }

--- a/feature/email/src/main/java/com/bitgoeul/email/InputNewPasswordScreen.kt
+++ b/feature/email/src/main/java/com/bitgoeul/email/InputNewPasswordScreen.kt
@@ -45,7 +45,7 @@ internal fun InputNewPasswordRoute(
         onBackClicked = onBackClicked,
         focusManager = focusManager,
         onNextClicked = { newPassword ->
-            viewModel.newPassword.value = newPassword
+            viewModel.onNewPassword(newPassword)
             viewModel.findPassword()
             onNextClicked()
         },
@@ -139,11 +139,11 @@ internal fun InputNewPasswordScreen(
                     Spacer(modifier = modifier.weight(1f))
 
                     BitgoeulButton(
-                        text = "다음으로",
-                        modifier = Modifier
+                        modifier = modifier
                             .padding(bottom = 14.dp)
                             .fillMaxWidth()
                             .height(52.dp),
+                        text = "다음으로",
                         state = if (firstInputPassword.value.isNotEmpty() && secondInputPassword.value.isNotEmpty()) ButtonState.Enable else ButtonState.Disable,
                         onClicked = {
                             if (passwordPattern.matches(firstInputPassword.value)) {

--- a/feature/email/src/main/java/com/bitgoeul/email/InputNewPasswordScreen.kt
+++ b/feature/email/src/main/java/com/bitgoeul/email/InputNewPasswordScreen.kt
@@ -1,5 +1,6 @@
 package com.bitgoeul.email
 
+import android.content.Context
 import androidx.activity.ComponentActivity
 import androidx.compose.foundation.background
 import androidx.compose.foundation.gestures.detectTapGestures
@@ -39,11 +40,9 @@ internal fun InputNewPasswordRoute(
     onNextClicked: () -> Unit,
     viewModel: EmailViewModel = hiltViewModel(LocalContext.current as ComponentActivity)
 ) {
-    val focusManager = LocalFocusManager.current
 
     InputNewPasswordScreen(
         onBackClicked = onBackClicked,
-        focusManager = focusManager,
         onNextClicked = { newPassword ->
             viewModel.onNewPassword(newPassword)
             viewModel.findPassword()
@@ -55,105 +54,103 @@ internal fun InputNewPasswordRoute(
 @Composable
 internal fun InputNewPasswordScreen(
     modifier: Modifier = Modifier,
-    focusManager: FocusManager,
+    focusManager: FocusManager = LocalFocusManager.current,
     onBackClicked: () -> Unit,
     onNextClicked: (String) -> Unit,
+    context: Context = LocalContext.current
 ) {
     val passwordPattern = Regex("^(?=.*[A-Za-z0-9])[A-Za-z0-9!@#$%^&*]{8,24}$")
     val firstInputPassword = remember { mutableStateOf("") }
     val secondInputPassword = remember { mutableStateOf("") }
-    val context = LocalContext.current
 
-    CompositionLocalProvider(LocalFocusManager provides focusManager) {
-        BitgoeulAndroidTheme { color, typography ->
-            Surface {
-                Column(
-                    modifier = modifier
-                        .background(color = color.WHITE)
-                        .padding(horizontal = 28.dp)
-                        .fillMaxSize()
-                        .pointerInput(Unit) {
-                            detectTapGestures {
-                                focusManager.clearFocus()
-                            }
+    BitgoeulAndroidTheme { color, typography ->
+        Surface {
+            Column(
+                modifier = modifier
+                    .background(color = color.WHITE)
+                    .padding(horizontal = 28.dp)
+                    .fillMaxSize()
+                    .pointerInput(Unit) {
+                        detectTapGestures {
+                            focusManager.clearFocus()
                         }
-                ) {
-                    Spacer(modifier = modifier.height(20.dp))
-
-                    GoBackTopBar(
-                        icon = { GoBackIcon() },
-                        text = stringResource(id = R.string.go_back)
-                    ) {
-                        onBackClicked()
                     }
+            ) {
+                Spacer(modifier = modifier.height(20.dp))
 
-                    Spacer(modifier = modifier.height(16.dp))
-
-                    Text(
-                        text = "만나서 반가워요!",
-                        style = typography.titleLarge,
-                        color = color.BLACK
-                    )
-
-                    Text(
-                        text = "어디서 오셨나요?",
-                        style = typography.bodySmall,
-                        color = color.G2
-                    )
-
-                    Spacer(modifier = modifier.height(32.dp))
-
-
-                    DefaultTextField(
-                        modifier = modifier.fillMaxWidth(),
-                        onValueChange = { inputPassword ->
-                            firstInputPassword.value = inputPassword
-                        },
-                        errorText = "비밀번호는 8~24자 영문, 숫자, 특수문자 1개 이상이어야 합니다.",
-                        isDisabled = false,
-                        isError = !passwordPattern.matches(firstInputPassword.value) && firstInputPassword.value.isNotEmpty(),
-                        isLinked = false,
-                        isReverseTrailingIcon = false,
-                        onButtonClicked = {},
-                        placeholder = "8~24자 영문, 숫자, 특수문자 1개 이상",
-                        visualTransformationState = true
-                    )
-
-                    Spacer(modifier = modifier.height(16.dp))
-
-                    DefaultTextField(
-                        modifier = modifier.fillMaxWidth(),
-                        onValueChange = { inputPassword ->
-                            secondInputPassword.value = inputPassword
-                        },
-                        errorText = "비밀번호가 일치하지 않습니다.",
-                        isDisabled = false,
-                        isError = firstInputPassword.value != secondInputPassword.value,
-                        isLinked = false,
-                        isReverseTrailingIcon = false,
-                        onButtonClicked = {},
-                        placeholder = "비밀번호 확인",
-                        visualTransformationState = true
-                    )
-
-                    Spacer(modifier = modifier.weight(1f))
-
-                    BitgoeulButton(
-                        modifier = modifier
-                            .padding(bottom = 14.dp)
-                            .fillMaxWidth()
-                            .height(52.dp),
-                        text = "다음으로",
-                        state = if (firstInputPassword.value.isNotEmpty() && secondInputPassword.value.isNotEmpty()) ButtonState.Enable else ButtonState.Disable,
-                        onClicked = {
-                            if (passwordPattern.matches(firstInputPassword.value)) {
-                                onNextClicked(secondInputPassword.value)
-                            } else {
-                                makeToast(context, "비밀번호는 8~24자 영문, 숫자, 특수문자 1개 이상이어야 합니다.")
-                            }
-                        }
-                    )
+                GoBackTopBar(
+                    icon = { GoBackIcon() },
+                    text = stringResource(id = R.string.go_back)
+                ) {
+                    onBackClicked()
                 }
+
+                Spacer(modifier = modifier.height(16.dp))
+
+                Text(
+                    text = "만나서 반가워요!",
+                    style = typography.titleLarge,
+                    color = color.BLACK
+                )
+
+                Text(
+                    text = "어디서 오셨나요?",
+                    style = typography.bodySmall,
+                    color = color.G2
+                )
+
+                Spacer(modifier = modifier.height(32.dp))
+
+
+                DefaultTextField(
+                    modifier = modifier.fillMaxWidth(),
+                    onValueChange = { inputPassword ->
+                        firstInputPassword.value = inputPassword
+                    },
+                    errorText = "비밀번호는 8~24자 영문, 숫자, 특수문자 1개 이상이어야 합니다.",
+                    isDisabled = false,
+                    isError = !passwordPattern.matches(firstInputPassword.value) && firstInputPassword.value.isNotEmpty(),
+                    isLinked = false,
+                    isReverseTrailingIcon = false,
+                    onButtonClicked = {},
+                    placeholder = "8~24자 영문, 숫자, 특수문자 1개 이상",
+                    visualTransformationState = true
+                )
+
+                Spacer(modifier = modifier.height(16.dp))
+
+                DefaultTextField(
+                    modifier = modifier.fillMaxWidth(),
+                    onValueChange = { inputPassword ->
+                        secondInputPassword.value = inputPassword
+                    },
+                    errorText = "비밀번호가 일치하지 않습니다.",
+                    isDisabled = false,
+                    isError = firstInputPassword.value != secondInputPassword.value,
+                    isLinked = false,
+                    isReverseTrailingIcon = false,
+                    onButtonClicked = {},
+                    placeholder = "비밀번호 확인",
+                    visualTransformationState = true
+                )
+
+                Spacer(modifier = modifier.weight(1f))
+
+                BitgoeulButton(
+                    modifier = modifier
+                        .padding(bottom = 14.dp)
+                        .fillMaxWidth()
+                        .height(52.dp),
+                    text = "다음으로",
+                    state = if (firstInputPassword.value.isNotEmpty() && secondInputPassword.value.isNotEmpty()) ButtonState.Enable else ButtonState.Disable,
+                    onClicked = {
+                        if (passwordPattern.matches(firstInputPassword.value)) {
+                            onNextClicked(secondInputPassword.value)
+                        } else {
+                            makeToast(context, "비밀번호는 8~24자 영문, 숫자, 특수문자 1개 이상이어야 합니다.")
+                        }
+                    }
+                )
             }
         }
     }

--- a/feature/email/src/main/java/com/bitgoeul/email/PasswordChangeSuccessScreen.kt
+++ b/feature/email/src/main/java/com/bitgoeul/email/PasswordChangeSuccessScreen.kt
@@ -68,11 +68,11 @@ internal fun PasswordChangeSuccessScreen(
                 Spacer(modifier = modifier.weight(1f))
 
                 BitgoeulButton(
-                    text = "돌아가기",
-                    modifier = Modifier
+                    modifier = modifier
                         .padding(bottom = 14.dp)
                         .fillMaxWidth()
                         .height(52.dp),
+                    text = "돌아가기",
                     state = ButtonState.Enable,
                     onClicked = {
                         onBackClicked()

--- a/feature/email/src/main/java/com/bitgoeul/email/viewmodel/EmailViewModel.kt
+++ b/feature/email/src/main/java/com/bitgoeul/email/viewmodel/EmailViewModel.kt
@@ -28,7 +28,9 @@ class EmailViewModel @Inject constructor(
 ) : ViewModel() {
     companion object {
         private const val EMAIL = "email"
-
+        private const val NEW_PASSWORD = "newPassword"
+        private const val FIRST_INPUT_PASSWORD = "firstInputPassword"
+        private const val SECOND_INPUT_PASSWORD = "secondInputPassword"
     }
 
     private val _sendLinkToEmailResponse = MutableStateFlow<Event<Unit>>(Event.Loading)
@@ -42,8 +44,11 @@ class EmailViewModel @Inject constructor(
 
     internal var email = savedStateHandle.getStateFlow(key = EMAIL, initialValue = "")
 
-    var newPassword = mutableStateOf("")
-        private set
+    private var newPassword = savedStateHandle.getStateFlow(key = NEW_PASSWORD, initialValue = "")
+
+    internal var firstInputPassword = savedStateHandle.getStateFlow(key = FIRST_INPUT_PASSWORD, initialValue = "")
+
+    internal var secondInputPassword = savedStateHandle.getStateFlow(key = SECOND_INPUT_PASSWORD, initialValue = "")
 
     internal fun getEmailAuthenticateStatus() = viewModelScope.launch {
        getEmailAuthenticateStatusUseCase(
@@ -93,4 +98,10 @@ class EmailViewModel @Inject constructor(
     }
 
     internal fun onEmailChange(value: String) { savedStateHandle[EMAIL] = value }
+
+    internal fun onNewPasswordChange(value: String) { savedStateHandle[NEW_PASSWORD] = value }
+
+    internal fun onFirstInputPasswordChange(value: String) { savedStateHandle[FIRST_INPUT_PASSWORD] = value }
+
+    internal fun onSecondInputPasswordChange(value: String) { savedStateHandle[SECOND_INPUT_PASSWORD] = value }
 }

--- a/feature/email/src/main/java/com/bitgoeul/email/viewmodel/EmailViewModel.kt
+++ b/feature/email/src/main/java/com/bitgoeul/email/viewmodel/EmailViewModel.kt
@@ -1,6 +1,7 @@
 package com.bitgoeul.email.viewmodel
 
 import androidx.compose.runtime.mutableStateOf
+import androidx.lifecycle.SavedStateHandle
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
 import com.msg.common.errorhandling.errorHandling
@@ -23,7 +24,12 @@ class EmailViewModel @Inject constructor(
     private val sendLinkToEmailUseCase: SendLinkToEmailUseCase,
     private val getEmailAuthenticateStatusUseCase: GetEmailAuthenticateStatusUseCase,
     private val findPasswordUseCase: FindPasswordUseCase,
+    private val savedStateHandle: SavedStateHandle
 ) : ViewModel() {
+    companion object {
+        private const val EMAIL = "email"
+        private const val NEW_PASSWORD = "newPassword"
+    }
 
     private val _sendLinkToEmailResponse = MutableStateFlow<Event<Unit>>(Event.Loading)
     val sendLinkToEmailResponse = _sendLinkToEmailResponse.asStateFlow()
@@ -34,11 +40,9 @@ class EmailViewModel @Inject constructor(
     private val _findPasswordResponse = MutableStateFlow<Event<Unit>>(Event.Loading)
     val findPasswordResponse = _findPasswordResponse.asStateFlow()
 
-    var email = mutableStateOf("")
-        private set
+    internal var email = savedStateHandle.getStateFlow(key = EMAIL, initialValue = "")
 
-    var newPassword = mutableStateOf("")
-        private set
+    internal var newPassword = savedStateHandle.getStateFlow(key = NEW_PASSWORD, initialValue = "")
 
     internal fun getEmailAuthenticateStatus() = viewModelScope.launch {
        getEmailAuthenticateStatusUseCase(
@@ -86,4 +90,8 @@ class EmailViewModel @Inject constructor(
             _findPasswordResponse.value = error.errorHandling()
         }
     }
+
+    internal fun onEmailChange(value: String) { savedStateHandle[EMAIL] = value }
+
+    internal fun onNewPassword(value: String) { savedStateHandle[NEW_PASSWORD] = value }
 }

--- a/feature/email/src/main/java/com/bitgoeul/email/viewmodel/EmailViewModel.kt
+++ b/feature/email/src/main/java/com/bitgoeul/email/viewmodel/EmailViewModel.kt
@@ -28,7 +28,7 @@ class EmailViewModel @Inject constructor(
 ) : ViewModel() {
     companion object {
         private const val EMAIL = "email"
-        private const val NEW_PASSWORD = "newPassword"
+
     }
 
     private val _sendLinkToEmailResponse = MutableStateFlow<Event<Unit>>(Event.Loading)
@@ -42,7 +42,8 @@ class EmailViewModel @Inject constructor(
 
     internal var email = savedStateHandle.getStateFlow(key = EMAIL, initialValue = "")
 
-    internal var newPassword = savedStateHandle.getStateFlow(key = NEW_PASSWORD, initialValue = "")
+    var newPassword = mutableStateOf("")
+        private set
 
     internal fun getEmailAuthenticateStatus() = viewModelScope.launch {
        getEmailAuthenticateStatusUseCase(
@@ -92,6 +93,4 @@ class EmailViewModel @Inject constructor(
     }
 
     internal fun onEmailChange(value: String) { savedStateHandle[EMAIL] = value }
-
-    internal fun onNewPassword(value: String) { savedStateHandle[NEW_PASSWORD] = value }
 }


### PR DESCRIPTION
## 💡 개요
- Email 모듈에서 리팩토링이 필요한 부분이 존재합니다
## 📃 작업내용
- Email 모듈을 리팩토링 했습니다
 - 컴포저블에서 상태를 관리를 하고 있어 viewModel에서 SavedStateHandle을 사용해서 상태 관리를 할 수 있도록 수정했습니다
 - checkRegex 파일의 코드가 불필요하게 긴 부분이 있서 코드를 간소화했습니다
 - 코드 컨벤션에 맞지 않은 코드를 수정했습니다
 - CompositionLocal Provider를 사용하지 않고 직접 LocalFocusManager.current를 사용할 수 있도록 수정했습니다
 - 상태 호이스팅을 했습니다 
## 🔀 변경사항
- refactor EmailViewModel
- refactor EmailSendInformScreen
- refactor InputEmailScreen
- refactor InputNewPasswordSrceen
- refactor PasswordChangeSuccessScreen