### PR TITLE
🔀 :: (#265) - Use rememberSaveable

### DIFF
--- a/feature/certification/src/main/java/com/msg/certification/AddCertificationScreen.kt
+++ b/feature/certification/src/main/java/com/msg/certification/AddCertificationScreen.kt
@@ -13,7 +13,7 @@ import androidx.compose.foundation.layout.padding
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
-import androidx.compose.runtime.remember
+import androidx.compose.runtime.saveable.rememberSaveable
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.focus.FocusManager
 import androidx.compose.ui.input.pointer.pointerInput
@@ -65,7 +65,7 @@ internal fun AddCertificationScreen(
     selectedDate: LocalDate?,
     onAddClicked: (name: String, acquisitionDate: LocalDate) -> Unit
 ) {
-    val (isDate, setIsDate) = remember { mutableStateOf(selectedDate) }
+    val (isDate, setIsDate) = rememberSaveable { mutableStateOf(selectedDate) }
 
     BitgoeulAndroidTheme { colors, _ ->
         Box(

--- a/feature/club/src/main/java/com/msg/club/ClubScreen.kt
+++ b/feature/club/src/main/java/com/msg/club/ClubScreen.kt
@@ -12,13 +12,12 @@ import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
-import androidx.compose.foundation.rememberScrollState
 import androidx.compose.material3.IconButton
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.mutableStateOf
-import androidx.compose.runtime.remember
+import androidx.compose.runtime.saveable.rememberSaveable
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.platform.LocalContext
@@ -97,7 +96,7 @@ internal fun ClubScreen(
     onSettingClicked: (String) -> Unit,
     onItemClicked: (Long) -> Unit
 ) {
-    val (isDialogOpened, setIsDialogOpened) = remember { mutableStateOf(false) }
+    val (isDialogOpened, setIsDialogOpened) = rememberSaveable { mutableStateOf(false) }
     val schoolList = HighSchool.entries.getSchoolNameFromEnum()
 
     BitgoeulAndroidTheme { colors, typography ->  

--- a/feature/email/src/main/java/com/bitgoeul/email/EmailSendInformScreen.kt
+++ b/feature/email/src/main/java/com/bitgoeul/email/EmailSendInformScreen.kt
@@ -76,9 +76,6 @@ internal fun EmailSendInformRoute(
     )
 }
 
-
-
-
 private suspend fun getEmailAuthenticateStatus(
     viewModel: EmailViewModel,
     onSuccess: (data: GetEmailAuthenticateStatusEntity) -> Unit,

--- a/feature/my-page/src/main/java/com/example/my_page/MyPageScreen.kt
+++ b/feature/my-page/src/main/java/com/example/my_page/MyPageScreen.kt
@@ -12,7 +12,7 @@ import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.mutableStateOf
-import androidx.compose.runtime.remember
+import androidx.compose.runtime.saveable.rememberSaveable
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
@@ -78,7 +78,7 @@ internal fun MyPageScreen(
     data: GetMyPageEntity,
     modifier: Modifier = Modifier
 ) {
-    val (isDialogOpen, setIsDialogOpen) = remember { mutableStateOf(false) }
+    val (isDialogOpen, setIsDialogOpen) = rememberSaveable { mutableStateOf(false) }
 
     BitgoeulAndroidTheme { colors, typography ->
         Column(

--- a/feature/my-page/src/main/java/com/example/my_page/PasswordChangeScreen.kt
+++ b/feature/my-page/src/main/java/com/example/my_page/PasswordChangeScreen.kt
@@ -13,7 +13,7 @@ import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
-import androidx.compose.runtime.remember
+import androidx.compose.runtime.saveable.rememberSaveable
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.focus.FocusManager
@@ -76,10 +76,10 @@ internal fun PasswordChangeScreen(
     onSuccessScreenButtonClicked: () -> Unit,
     onBackClicked: () -> Unit
 ) {
-    val isWrongPassword by remember { mutableStateOf(false) }
-    var isSamePassword by remember { mutableStateOf(true) }
+    val isWrongPassword by rememberSaveable { mutableStateOf(false) }
+    var isSamePassword by rememberSaveable { mutableStateOf(true) }
 
-    val (isShowSuccessScreen, setIsShowSuccessScreen) = remember { mutableStateOf(false) }
+    val (isShowSuccessScreen, setIsShowSuccessScreen) = rememberSaveable { mutableStateOf(false) }
 
     BitgoeulAndroidTheme { colors, typography ->
         Surface(


### PR DESCRIPTION
## 💡 개요
- remember를 사용하는 것보다 rememberSaveable을 사용하는 것이 더 안전해보입니다
## 📃 작업내용
- remember를 rememberSaveable로 수정하였습니다
## 🔀 변경사항
- refactor ClubScreen
- refactor EmailSendImformScreen
- refactor Add CertificationScreen
