### PR TITLE
🔀 :: (#264) - refactor login module

### DIFF
--- a/feature/login/src/main/java/com/bitgoeul/login/LoginScreen.kt
+++ b/feature/login/src/main/java/com/bitgoeul/login/LoginScreen.kt
@@ -169,7 +169,7 @@ internal fun LoginScreen(
                             onEmailChange(it)
                         },
                         isError = isEmailErrorStatus,
-                        onButtonClicked = { setIsEmailErrorStatus(isTextStatus.isNullOrBlank()) },
+                        onButtonClicked = { setIsEmailErrorStatus(isTextStatus.isBlank()) },
                         isLinked = false,
                         isDisabled = false,
                         isReadOnly = false,

--- a/feature/login/src/main/java/com/bitgoeul/login/LoginScreen.kt
+++ b/feature/login/src/main/java/com/bitgoeul/login/LoginScreen.kt
@@ -191,7 +191,7 @@ internal fun LoginScreen(
                         placeholder = stringResource(id = R.string.password),
                         errorText = stringResource(id = R.string.wrong_password),
                         onValueChange = onPasswordChange,
-                        onLinkClicked = { onFindPasswordClicked() },
+                        onLinkClicked = onFindPasswordClicked,
                         isError = isPasswordErrorStatus,
                         isLinked = true,
                         linkText = stringResource(id = R.string.find_password),

--- a/feature/login/src/main/java/com/bitgoeul/login/LoginScreen.kt
+++ b/feature/login/src/main/java/com/bitgoeul/login/LoginScreen.kt
@@ -122,7 +122,6 @@ internal fun LoginScreen(
     val (isEmailErrorStatus, setIsEmailErrorStatus) = rememberSaveable { mutableStateOf(false) }
     val isPasswordErrorStatus by rememberSaveable{ mutableStateOf(false) }
     val isErrorTextShow by rememberSaveable { mutableStateOf(false) }
-    var isTextStatus = ""
 
     BitgoeulAndroidTheme { color, type ->
         Surface {
@@ -164,12 +163,9 @@ internal fun LoginScreen(
                             .height(54.dp),
                         placeholder = stringResource(id = R.string.email),
                         errorText = stringResource(id = R.string.error_text_email),
-                        onValueChange = {
-                            isTextStatus = it
-                            onEmailChange(it)
-                        },
+                        onValueChange = onEmailChange,
                         isError = isEmailErrorStatus,
-                        onButtonClicked = { setIsEmailErrorStatus(isTextStatus.isBlank()) },
+                        onButtonClicked = { setIsEmailErrorStatus(email.isBlank()) },
                         isLinked = false,
                         isDisabled = false,
                         isReadOnly = false,

--- a/feature/login/src/main/java/com/bitgoeul/login/viewmodel/AuthViewModel.kt
+++ b/feature/login/src/main/java/com/bitgoeul/login/viewmodel/AuthViewModel.kt
@@ -1,5 +1,6 @@
 package com.bitgoeul.login.viewmodel
 
+import androidx.lifecycle.SavedStateHandle
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
 import com.msg.common.errorhandling.errorHandling
@@ -19,12 +20,21 @@ import javax.inject.Inject
 class AuthViewModel @Inject constructor(
     private val loginUseCase: LoginUseCase,
     private val saveTokenUseCase: SaveTokenUseCase,
+    private val savedStateHandle: SavedStateHandle
 ) : ViewModel() {
+    companion object {
+        private const val EMAIL = "email"
+        private const val PASSWORD = "password"
+    }
     private val _saveTokenResponse = MutableStateFlow<Event<Nothing>>(Event.Loading)
     val saveTokenRequest = _saveTokenResponse.asStateFlow()
 
     private val _loginResponse = MutableStateFlow<Event<AuthTokenEntity>>(Event.Loading)
     val loginResponse = _loginResponse.asStateFlow()
+
+    internal var email = savedStateHandle.getStateFlow(key = EMAIL, initialValue = "")
+
+    internal var password = savedStateHandle.getStateFlow(key = PASSWORD, initialValue = "")
 
     internal fun login(
         email: String,
@@ -58,4 +68,8 @@ class AuthViewModel @Inject constructor(
             _saveTokenResponse.value = it.errorHandling()
         }
     }
+
+    internal fun onEmailChange(value: String) { savedStateHandle[EMAIL] = value }
+
+    internal fun onPasswordChange(value: String) { savedStateHandle[PASSWORD] = value }
 }


### PR DESCRIPTION
## 💡 개요
- Login 모듈에서 리팩토링이 필요한 부분이 있습니다
## 📃 작업내용
- Login 모듈을 리팩토링 하였습니다
    - 컴포저블 안에서 상태를 관리하는 것을 ViewModel에서 SavedStateHandle을 사용하여 관리할 수 있도록 수정하였습니다
    - 상태 호이스팅을 사용하였습니다
    - 컴포저블에서 remember를 사용하는 것을 ViewModel으로 옮기기 어려운 것을 rememberSaveable을 사용하여 보다 안전하게 관리할. 수 있도록 수정하였습니다
    - 코드 컨벤션에 맞게 수정하였습니다
    - 구조 분해 선언을 사용하였습니다
    - isTextStatus를 삭제하고 email 상태를 직접 사용할 수 있도록 수정하였습니다
    - isNullOrBlank()로 되어있는 email은 String 문자열 이기때문에 Null 값이 될 수 없으므로 isBlank()로 수정하였습니다
    - Modifier을 modifier인자로 받아서 사용하도록 수정하였습니다
## 🔀 변경사항
- refactor LoginScreen
- refactor AuthViewModel