### PR TITLE
🔀 :: (#268) - refactor main module

### DIFF
--- a/feature/main/src/main/java/com/msg/main/MainPageScreen.kt
+++ b/feature/main/src/main/java/com/msg/main/MainPageScreen.kt
@@ -2,6 +2,7 @@ package com.msg.main
 
 import android.app.Activity
 import androidx.compose.foundation.Image
+import androidx.compose.foundation.ScrollState
 import androidx.compose.foundation.background
 import androidx.compose.foundation.horizontalScroll
 import androidx.compose.foundation.layout.Arrangement
@@ -133,15 +134,14 @@ internal fun MainPageScreen(
     question: String,
     onAnswerChange: (String) -> Unit,
     onQuestionChange: (String) -> Unit,
+    scrollState: ScrollState = rememberScrollState(),
+    highSchoolScrollState: ScrollState = rememberScrollState(),
     data: List<GetFAQDetailEntity>,
     event: Event<List<GetFAQDetailEntity>>,
     role: String,
     onAddClicked: (question: String, answer: String) -> Unit,
     onDialogButtonClicked: () -> Unit
 ) {
-    val scrollState = rememberScrollState()
-    val highSchoolScrollState = rememberScrollState()
-
     val highSchoolDoingList = listOf("교육과정 운영", "진로 지도", "학생 관리")
     val collegeDoingList = listOf("기업 연계 교육", "심화 교육", "후학습 지원")
     val enterpriseDoingList = listOf("현장 맞춤형 교육", "현장 실습", "고졸 채용")

--- a/feature/main/src/main/java/com/msg/main/MainPageScreen.kt
+++ b/feature/main/src/main/java/com/msg/main/MainPageScreen.kt
@@ -1,6 +1,5 @@
 package com.msg.main
 
-import com.msg.model.enumdata.Authority
 import android.app.Activity
 import androidx.compose.foundation.Image
 import androidx.compose.foundation.background
@@ -20,8 +19,6 @@ import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.getValue
-import androidx.compose.runtime.mutableStateOf
-import androidx.compose.runtime.remember
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.layout.ContentScale
@@ -60,8 +57,8 @@ internal fun MainPageScreenRoute(
     viewModel: FaqViewModel = hiltViewModel(),
     onLoginClicked: () -> Unit
 ) {
-    val answer by viewModel.answer.collectAsStateWithLifecycle()
-    val question by viewModel.question.collectAsStateWithLifecycle()
+    val answerValue by viewModel.answer.collectAsStateWithLifecycle()
+    val questionValue by viewModel.question.collectAsStateWithLifecycle()
 
     val role = viewModel.role
     var error: Event<List<GetFAQDetailEntity>> = Event.Loading
@@ -84,8 +81,8 @@ internal fun MainPageScreenRoute(
     }
 
     MainPageScreen(
-        answer = answer,
-        question = question,
+        answer = answerValue,
+        question = questionValue,
         onAnswerChange = viewModel::onAnswerChange,
         onQuestionChange = viewModel::onQuestionChange,
         data = viewModel.faqList,

--- a/feature/main/src/main/java/com/msg/main/MainPageScreen.kt
+++ b/feature/main/src/main/java/com/msg/main/MainPageScreen.kt
@@ -19,6 +19,7 @@ import androidx.compose.material3.Surface
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
+import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
 import androidx.compose.ui.Alignment
@@ -28,6 +29,7 @@ import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.res.painterResource
 import androidx.compose.ui.unit.dp
 import androidx.hilt.navigation.compose.hiltViewModel
+import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import com.msg.common.event.Event
 import com.msg.design_system.R
 import com.msg.design_system.component.dialog.BitgoeulAlertDialog
@@ -58,6 +60,9 @@ internal fun MainPageScreenRoute(
     viewModel: FaqViewModel = hiltViewModel(),
     onLoginClicked: () -> Unit
 ) {
+    val answer by viewModel.answer.collectAsStateWithLifecycle()
+    val question by viewModel.question.collectAsStateWithLifecycle()
+
     val role = viewModel.role
     var error: Event<List<GetFAQDetailEntity>> = Event.Loading
     var isReLaunched = false
@@ -79,6 +84,10 @@ internal fun MainPageScreenRoute(
     }
 
     MainPageScreen(
+        answer = answer,
+        question = question,
+        onAnswerChange = viewModel::onAnswerChange,
+        onQuestionChange = viewModel::onQuestionChange,
         data = viewModel.faqList,
         event = error,
         role = role,
@@ -123,6 +132,10 @@ private suspend fun getFaqList(
 @Composable
 internal fun MainPageScreen(
     modifier: Modifier = Modifier,
+    answer: String,
+    question: String,
+    onAnswerChange: (String) -> Unit,
+    onQuestionChange: (String) -> Unit,
     data: List<GetFAQDetailEntity>,
     event: Event<List<GetFAQDetailEntity>>,
     role: String,
@@ -147,13 +160,9 @@ internal fun MainPageScreen(
         NBCollegeData
     )
 
-    val questionValue = remember { mutableStateOf("") }
-    val answerValue = remember { mutableStateOf("") }
-
     BitgoeulAndroidTheme { colors, typography ->
         Surface(
-            modifier = modifier
-                .fillMaxSize()
+            modifier = modifier.fillMaxSize()
         ) {
             Column(
                 modifier = modifier
@@ -322,15 +331,11 @@ internal fun MainPageScreen(
                 FaqSection(data = data)
                 if (role == "ROLE_ADMIN") {
                     AddFaqItem(
-                        questionValue = questionValue.value,
-                        onQuestionValueChanged = {
-                            questionValue.value = it
-                        },
-                        answerValue = answerValue.value,
-                        onAnswerValueChanged = {
-                            answerValue.value = it
-                        },
-                        onAddClicked = { onAddClicked(questionValue.value, answerValue.value) }
+                        questionValue = question,
+                        onQuestionValueChanged = onQuestionChange,
+                        answerValue = answer,
+                        onAnswerValueChanged = onAnswerChange,
+                        onAddClicked = { onAddClicked(question, answer) }
                     )
                 }
                 Spacer(modifier = modifier.height(24.dp))
@@ -391,6 +396,10 @@ fun MainPageScreenPre() {
         onAddClicked = {_,_->},
         role = "ROLE_ADMIN",
         event = Event.Success(),
-        onDialogButtonClicked = {}
+        onDialogButtonClicked = {},
+        answer = "",
+        question = "",
+        onAnswerChange = {},
+        onQuestionChange = {}
     )
 }

--- a/feature/main/src/main/java/com/msg/main/MainPageScreen.kt
+++ b/feature/main/src/main/java/com/msg/main/MainPageScreen.kt
@@ -150,7 +150,7 @@ internal fun MainPageScreen(
     val enterpriseDoingList = listOf("현장 맞춤형 교육", "현장 실습", "고졸 채용")
     val governmentDoingList = listOf("산업 인력 분석", "특화프로그램 운영", "고졸채용네트워크 구축")
 
-    val highSchoolList = HighSchool.values()
+    val highSchoolList = HighSchool.entries
     val collegeList = listOf(
         SWCollegeData,
         HNCollegeData,

--- a/feature/main/src/main/java/com/msg/main/MainPageScreen.kt
+++ b/feature/main/src/main/java/com/msg/main/MainPageScreen.kt
@@ -20,6 +20,9 @@ import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.layout.ContentScale
@@ -62,7 +65,7 @@ internal fun MainPageScreenRoute(
     val questionValue by viewModel.question.collectAsStateWithLifecycle()
 
     val role = viewModel.role
-    var error: Event<List<GetFAQDetailEntity>> = Event.Loading
+    var error: Event<List<GetFAQDetailEntity>> by remember { mutableStateOf(Event.Loading) }
     var isReLaunched = false
     val activity = LocalContext.current as Activity
 

--- a/feature/main/src/main/java/com/msg/main/component/AddFaqItem.kt
+++ b/feature/main/src/main/java/com/msg/main/component/AddFaqItem.kt
@@ -17,8 +17,10 @@ import androidx.compose.material3.HorizontalDivider
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.derivedStateOf
+import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
+import androidx.compose.runtime.saveable.rememberSaveable
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.tooling.preview.Preview
@@ -34,9 +36,9 @@ internal fun AddFaqItem(
     onAnswerValueChanged: (String) -> Unit,
     onAddClicked: () -> Unit
 ) {
-    val isSelected = remember { mutableStateOf(false) }
-    val questionHintVisible = remember { derivedStateOf { questionValue.isEmpty() } }
-    val answerHintVisible = remember { derivedStateOf { answerValue.isEmpty() } }
+    val (isSelected, setIsSelected) = rememberSaveable { mutableStateOf(false) }
+    val questionHintVisible by remember { derivedStateOf { questionValue.isEmpty() } }
+    val answerHintVisible by remember { derivedStateOf { answerValue.isEmpty() } }
     val interactionSource = remember { MutableInteractionSource() }
 
     BitgoeulAndroidTheme { colors, typography ->
@@ -56,14 +58,14 @@ internal fun AddFaqItem(
                 )
         ) {
             Spacer(modifier = modifier.height(16.dp))
-            if (!isSelected.value) {
+            if (!isSelected) {
                 Text(
                     modifier = modifier
                         .clickable(
                             indication = null,
                             interactionSource = interactionSource
                         ) {
-                            isSelected.value = true
+                            setIsSelected(true)
                         }
                         .padding(horizontal = 20.dp),
                     text = "+ 자주 묻는 질문 추가하기",
@@ -82,7 +84,7 @@ internal fun AddFaqItem(
                                 style = typography.bodySmall,
                                 color = colors.P5
                             )
-                            if (questionHintVisible.value) Text(
+                            if (questionHintVisible) Text(
                                 text = "질문 작성하기",
                                 style = typography.bodySmall,
                                 color = colors.G1
@@ -110,7 +112,7 @@ internal fun AddFaqItem(
                                 style = typography.bodySmall,
                                 color = colors.P5
                             )
-                            if (answerHintVisible.value) Text(
+                            if (answerHintVisible) Text(
                                 text = "답변 작성하기",
                                 style = typography.bodySmall,
                                 color = colors.G1
@@ -136,7 +138,7 @@ internal fun AddFaqItem(
                             indication = null,
                             interactionSource = interactionSource
                         ) {
-                            isSelected.value = false
+                            setIsSelected(false)
                         },
                         text = "취소",
                         style = typography.bodySmall,
@@ -150,7 +152,7 @@ internal fun AddFaqItem(
                             interactionSource = interactionSource
                         ) {
                             onAddClicked()
-                            isSelected.value = false
+                            setIsSelected(false)
                         },
                         text = "작성",
                         style = typography.bodySmall,

--- a/feature/main/src/main/java/com/msg/main/component/FaqItem.kt
+++ b/feature/main/src/main/java/com/msg/main/component/FaqItem.kt
@@ -11,8 +11,10 @@ import androidx.compose.material3.ElevatedCard
 import androidx.compose.material3.HorizontalDivider
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
-import androidx.compose.runtime.remember
+import androidx.compose.runtime.saveable.rememberSaveable
+import androidx.compose.runtime.setValue
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.text.SpanStyle
 import androidx.compose.ui.text.buildAnnotatedString
@@ -30,7 +32,7 @@ internal fun FaqItem(
     modifier: Modifier = Modifier,
     data: GetFrequentlyAskedQuestionDetailEntity
 ) {
-    val isSelected = remember { mutableStateOf(false) }
+    var isSelected by rememberSaveable { mutableStateOf(false) }
 
     BitgoeulAndroidTheme { colors, _ ->
         ElevatedCard(
@@ -46,7 +48,7 @@ internal fun FaqItem(
                     shape = RoundedCornerShape(12.dp)
                 )
                 .clickable {
-                    isSelected.value = !isSelected.value
+                    isSelected = !isSelected
                 }
         ) {
             Spacer(modifier = modifier.height(16.dp))
@@ -75,7 +77,7 @@ internal fun FaqItem(
                     }
                 }
             )
-            if (isSelected.value) {
+            if (isSelected) {
                 Spacer(modifier = modifier.height(12.dp))
                 HorizontalDivider(
                     modifier = modifier.padding(horizontal = 13.dp),

--- a/feature/main/src/main/java/com/msg/main/component/SchoolClubGridView.kt
+++ b/feature/main/src/main/java/com/msg/main/component/SchoolClubGridView.kt
@@ -49,7 +49,6 @@ internal fun AutoSchoolClubGridView(
                 }
             }
         }
-
     }
 }
 
@@ -102,9 +101,10 @@ private fun List<String>.getActualList(): List<List<String>> {
 @Composable
 private fun String.getClubChipWidth(): Dp {
     val width = remember { mutableStateOf(0.dp) }
-    val shouldShowCompose = remember { mutableStateOf(true) }
+    val (shouldShowCompose, setShouldShowCompose) = remember { mutableStateOf(true) }
     val density = LocalDensity.current
-    if (shouldShowCompose.value) {
+
+    if (shouldShowCompose) {
         ClubChipView(
             clubName = this,
             modifier = Modifier.onGloballyPositioned {
@@ -113,7 +113,7 @@ private fun String.getClubChipWidth(): Dp {
             }
         )
     }
-    shouldShowCompose.value = false
+    setShouldShowCompose(false)
     return width.value
 }
 

--- a/feature/main/src/main/java/com/msg/main/viewmodel/FaqViewModel.kt
+++ b/feature/main/src/main/java/com/msg/main/viewmodel/FaqViewModel.kt
@@ -1,6 +1,7 @@
 package com.msg.main.viewmodel
 
 import androidx.compose.runtime.mutableStateListOf
+import androidx.lifecycle.SavedStateHandle
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
 import com.msg.common.errorhandling.errorHandling
@@ -22,7 +23,13 @@ class FaqViewModel @Inject constructor(
     private val addFAQUseCase: AddFAQUseCase,
     private val getFAQUseCase: GetFAQUseCase,
     private val getAuthorityUseCase: GetAuthorityUseCase,
+    private val savedStateHandle: SavedStateHandle
 ) : ViewModel() {
+
+    companion object {
+        private const val ANSWER = "answer"
+        private const val QUESTION = "question"
+    }
 
     val role = getRole().toString()
 
@@ -36,6 +43,10 @@ class FaqViewModel @Inject constructor(
         private set
 
     private var errorCode: Int = 200
+
+    internal var answer = savedStateHandle.getStateFlow(key = ANSWER, initialValue = "")
+
+    internal var question = savedStateHandle.getStateFlow(key = QUESTION, initialValue = "")
 
     internal fun addFaq(
         question: String,
@@ -75,4 +86,8 @@ class FaqViewModel @Inject constructor(
     private fun getRole() = viewModelScope.launch {
         getAuthorityUseCase()
     }
+
+    internal fun onAnswerChange(value: String) { savedStateHandle[ANSWER] = value }
+
+    internal fun onQuestionChange(value: String) { savedStateHandle[QUESTION] = value }
 }


### PR DESCRIPTION
## 💡 개요
- Main 모듈에 리팩토링이 필요한 부분이 존재합니다
## 📃 작업내용
- Main 모듈에 리팩토링이 필요한 부분이 있어 작업을 했습니다
   - 구조 분해 선언을 사용할 수 있도록 수정했습니다
   - by 키워드를 사용하였습니다
   - values()는 호출할 때마다 배열을 새로 생성하는데, entries는 이 값을 List로 반환해서 성능이 더 좋아보여 수정했습니다
   - rememberSaveable을 사용하면 더 좋을 것 같은 부분을 수정했습니다
   - 컴포저블 안에서 remember로 상태 관리를 하는 것을 ViewModel에서 SavedStateHandle로 처리합니다
   - 상태 호이스팅을 했습니다
## 🔀 변경사항
- refactor FaqViewModel
- refactor MainPageScreen
- refactor AddFaqItem
- refactor FaqItem
- refactor SchoolClubGridView